### PR TITLE
Retrieve currency directly from order when available

### DIFF
--- a/classes/requests/post/class-qliro-one-request-capture-order.php
+++ b/classes/requests/post/class-qliro-one-request-capture-order.php
@@ -38,22 +38,22 @@ class Qliro_One_Capture_Order extends Qliro_One_Request_Post {
 	 */
 	protected function get_body() {
 		$order_id               = $this->arguments['order_id'];
-		$payment_transaction_id = get_post_meta( $order_id, '_qliro_payment_transaction_id', true );
+		$order                  = wc_get_order( $order_id );
+		$payment_transaction_id = $order->get_meta( '_qliro_payment_transaction_id' );
 
 		// Check if the transaction id is empty. If it is we need to get it from the old transaction id meta.
 		if ( empty( $payment_transaction_id ) ) {
-			$payment_transaction_id = get_post_meta( $order_id, '_payment_transaction_id', true );
+			$payment_transaction_id = $order->get_meta( '_payment_transaction_id' );
 		}
 
 		$order_data           = new Qliro_One_Helper_Order();
-		$this->qliro_order_id = get_post_meta( $order_id, '_qliro_one_order_id', true );
-
+		$this->qliro_order_id = $order->get_meta( '_qliro_one_order_id' );
 
 		$body = array(
 			'RequestId'      => $order_data->generate_request_id(),
 			'MerchantApiKey' => $this->get_qliro_key(),
 			'OrderId'        => $this->qliro_order_id,
-			'Currency'       => get_woocommerce_currency(),
+			'Currency'       => $order->get_currency(),
 			'Shipments'      => array(
 				array(
 					'OrderItems' => $order_data::get_order_lines( $order_id ),

--- a/classes/requests/post/class-qliro-one-request-return-items.php
+++ b/classes/requests/post/class-qliro-one-request-return-items.php
@@ -40,14 +40,15 @@ class Qliro_One_Request_Return_Items extends Qliro_One_Request_Post {
 		$order_data             = new Qliro_One_Helper_Order();
 		$request_id             = $order_data->generate_request_id();
 		$order_id               = $this->arguments['order_id'];
+		$order                  = wc_get_order( $order_id );
 		$refund_order_id        = $this->arguments['refund_order_id'];
-		$this->qliro_order_id   = get_post_meta( $order_id, '_qliro_one_order_id', true );
-		$capture_transaction_id = get_post_meta( $order_id, '_qliro_order_captured', true );
+		$this->qliro_order_id   = $order->get_meta( '_qliro_one_order_id' );
+		$capture_transaction_id = $order->get_meta( '_qliro_order_captured' );
 		return array(
 			'RequestId'      => $request_id,
 			'MerchantApiKey' => $this->get_qliro_key(),
 			'OrderId'        => $this->qliro_order_id,
-			'Currency'       => get_woocommerce_currency(),
+			'Currency'       => $order->get_currency(),
 			'Returns'        => array(
 				array(
 					'PaymentTransactionId' => $capture_transaction_id,


### PR DESCRIPTION
Currently, we use `get_woocommerce_currency` which retrieves the store's default currency. This approach does not work with currency converters, since the currency in the checkout may differ from the store's default currency.

- retrieve the currency directly from the WC order.
- use `get_meta` instead of `get_post_meta`.