### PR TITLE
Adds support for delivery date (date start + date and)

### DIFF
--- a/classes/class-qliro-one-shipping-method-instance.php
+++ b/classes/class-qliro-one-shipping-method-instance.php
@@ -41,13 +41,13 @@ class Qliro_One_Shipping_Method_Instance {
 	 */
 	public function add_shipping_method_fields( $shipping_method_fields ) {
 		$settings_fields = array(
-			'qliro_shipping_settings' => array(
+			'qliro_shipping_settings'     => array(
 				'title'       => __( 'Qliro shipping settings', 'qliro-one-for-woocommerce' ),
 				'type'        => 'title',
 				'description' => __( 'These settings let you customize the shipping methods in Qliro One checkout, and only apply when you show the shipping options in the iframe. ', 'qliro-one-for-woocommerce' ),
 				'default'     => '',
 			),
-			'qliro_description'             => array(
+			'qliro_description'           => array(
 				'title'       => __( 'Description', 'qliro-one-for-woocommerce' ),
 				'type'        => 'textarea',
 				'default'     => '',
@@ -55,7 +55,43 @@ class Qliro_One_Shipping_Method_Instance {
 				'placeholder' => __( 'Maximum length is 100 characters per line and up to 3 lines.', 'qliro-one-for-woocommerce' ),
 				'desc_tip'    => true,
 			),
-			'qliro_category_display_name'   => array(
+			'qliro_delivery_date_start'   => array(
+				'title'   => __( 'Delivery start date', 'qliro-one-for-woocommerce' ),
+				'type'    => 'select',
+				'default' => 'none',
+				'options' => array(
+					'none' => __( 'None', 'qliro-one-for-woocommerce' ),
+					'1'    => __( 'Tomorrow', 'qliro-one-for-woocommerce' ),
+					'2'    => __( 'In 2 days', 'qliro-one-for-woocommerce' ),
+					'3'    => __( 'In 3 days', 'qliro-one-for-woocommerce' ),
+					'4'    => __( 'In 4 days', 'qliro-one-for-woocommerce' ),
+					'5'    => __( 'In 5 days', 'qliro-one-for-woocommerce' ),
+					'6'    => __( 'In 6 days', 'qliro-one-for-woocommerce' ),
+					'7'    => __( 'In 7 days', 'qliro-one-for-woocommerce' ),
+					'8'    => __( 'In 8 days', 'qliro-one-for-woocommerce' ),
+					'9'    => __( 'In 9 days', 'qliro-one-for-woocommerce' ),
+					'10'   => __( 'In 10 days', 'qliro-one-for-woocommerce' ),
+				),
+			),
+			'qliro_delivery_date_end'     => array(
+				'title'   => __( 'Delivery end date', 'qliro-one-for-woocommerce' ),
+				'type'    => 'select',
+				'default' => 'none',
+				'options' => array(
+					'none' => __( 'None', 'qliro-one-for-woocommerce' ),
+					'1'    => __( 'Tomorrow', 'qliro-one-for-woocommerce' ),
+					'2'    => __( 'In 2 days', 'qliro-one-for-woocommerce' ),
+					'3'    => __( 'In 3 days', 'qliro-one-for-woocommerce' ),
+					'4'    => __( 'In 4 days', 'qliro-one-for-woocommerce' ),
+					'5'    => __( 'In 5 days', 'qliro-one-for-woocommerce' ),
+					'6'    => __( 'In 6 days', 'qliro-one-for-woocommerce' ),
+					'7'    => __( 'In 7 days', 'qliro-one-for-woocommerce' ),
+					'8'    => __( 'In 8 days', 'qliro-one-for-woocommerce' ),
+					'9'    => __( 'In 9 days', 'qliro-one-for-woocommerce' ),
+					'10'   => __( 'In 10 days', 'qliro-one-for-woocommerce' ),
+				),
+			),
+			'qliro_category_display_name' => array(
 				'title'   => __( 'Category Display Name', 'qliro-one-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -65,7 +101,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'PICKUP'        => __( 'Pickup Point', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_label_display_name'      => array(
+			'qliro_label_display_name'    => array(
 				'title'   => __( 'Label Display Name', 'qliro-one-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -76,7 +112,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'free'    => __( 'Free', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_brand'                   => array(
+			'qliro_brand'                 => array(
 				'title'       => __( 'Brand', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -105,7 +141,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'Ups'         => 'UPS',
 				),
 			),
-			'qliro_option_label_eco'        => array(
+			'qliro_option_label_eco'      => array(
 				'title'       => __( 'ECO friendly label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -118,7 +154,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_express'    => array(
+			'qliro_option_label_express'  => array(
 				'title'       => __( 'Express shipping label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -131,7 +167,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_evening'    => array(
+			'qliro_option_label_evening'  => array(
 				'title'       => __( 'Evening delivery label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -144,7 +180,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_morning'    => array(
+			'qliro_option_label_morning'  => array(
 				'title'       => __( 'Morning delivery label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -157,7 +193,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_home'       => array(
+			'qliro_option_label_home'     => array(
 				'title'       => __( 'Home delivery label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -169,7 +205,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_box'        => array(
+			'qliro_option_label_box'      => array(
 				'title'       => __( 'Box delivery label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -181,7 +217,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-one-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_pickup'     => array(
+			'qliro_option_label_pickup'   => array(
 				'title'       => __( 'Pickup label', 'qliro-one-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -44,7 +44,9 @@ class Qliro_One_Helper_Shipping_Methods {
 				);
 
 				$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
-				$description     = isset( $method_settings['qliro_description'] ) ? $method_settings['qliro_description'] : '';
+
+				// Description.
+				$description = isset( $method_settings['qliro_description'] ) ? $method_settings['qliro_description'] : '';
 				if ( ! empty( $description ) ) {
 					// The trim is necessary to remove invisible characters (even when printed) such as "\n", otherwise, we'll end up with "empty" elements. The array_filter without arguments removes empty lines.
 					$lines = array_filter( array_map( 'trim', explode( "\n", $method_settings['qliro_description'] ) ) );
@@ -60,21 +62,25 @@ class Qliro_One_Helper_Shipping_Methods {
 					$options['Descriptions'] = array_slice( $description, 0, 3 );
 				}
 
+				// Category display name.
 				$category_display_name = isset( $method_settings['qliro_category_display_name'] ) ? $method_settings['qliro_category_display_name'] : 'none';
 				if ( 'none' !== $category_display_name ) {
 					$options['CategoryDisplayName'] = $category_display_name;
 				}
 
+				// Label display name.
 				$label_display_name = isset( $method_settings['qliro_label_display_name'] ) ? $method_settings['qliro_label_display_name'] : 'none';
 				if ( 'none' !== $label_display_name ) {
 					$options['LabelDisplayName'] = $label_display_name;
 				}
 
+				// Brand.
 				$brand = isset( $method_settings['qliro_brand'] ) ? $method_settings['qliro_brand'] : 'none';
 				if ( 'none' !== $brand ) {
 					$options['Brand'] = $brand;
 				}
 
+				// Option labels.
 				$option_labels = array();
 				foreach ( $method_settings as $key => $value ) {
 					if ( false !== strpos( $key, 'qliro_option_label_' ) && 'none' !== $value ) {
@@ -84,13 +90,23 @@ class Qliro_One_Helper_Shipping_Methods {
 						);
 					}
 				}
-
 				if ( ! empty( $option_labels ) ) {
 					$options['OptionLabels'] = $option_labels;
 				}
 
+				// Delivery date.
+				$delivery_date_start = isset( $method_settings['qliro_delivery_date_start'] ) ? $method_settings['qliro_delivery_date_start'] : 'none';
+				$delivery_date_end   = isset( $method_settings['qliro_delivery_date_end'] ) ? $method_settings['qliro_delivery_date_end'] : 'none';
+				if ( 'none' !== $delivery_date_start ) {
+					$options['DeliveryDateInfo']['DateStart'] = date( 'Y-m-d', strtotime( "+$delivery_date_start days" ) );
+				}
+				if ( 'none' !== $delivery_date_end ) {
+					$options['DeliveryDateInfo']['DateEnd'] = date( 'Y-m-d', strtotime( "+$delivery_date_end days" ) );
+				}
+
+				// Pickup points.
 				self::set_pickup_points( $options, $method );
-				$shipping_options[] = $options;
+				$shipping_options[] = apply_filters( 'qliro_one_shipping_option', $options, $method, $method_settings );
 
 			}
 		}


### PR DESCRIPTION
Also adds filter qliro_one_shipping_option so other plugins can hook into  shipping option about to be sent to Qliro.

Looks like this in checkout:
![image](https://github.com/krokedil/qliro-one-for-woocommerce/assets/985946/7f6176cf-97a0-45bb-a4d4-22e5c4a85d24)

Looks like this in shipping instance settings:
![image](https://github.com/krokedil/qliro-one-for-woocommerce/assets/985946/09c00dc9-b268-40c4-afd8-8ac9a2663f2b)
