### PR TITLE
Update to allow a diff of up to 0.1 when setting the tax rate to use …

### DIFF
--- a/classes/class-qliro-one-shipping-method.php
+++ b/classes/class-qliro-one-shipping-method.php
@@ -161,9 +161,8 @@ class Qliro_One_Shipping_Method extends WC_Shipping_Method {
 	 * @return array
 	 */
 	public static function get_shipping_tax_rate( $data ) {
-		$ex_vat  = $data['totalShippingPriceExVat'] ?? 0;
-		$inc_vat = $data['totalShippingPrice'] ?? 0;
-
+		$ex_vat              = $data['totalShippingPriceExVat'] ?? 0;
+		$inc_vat             = $data['totalShippingPrice'] ?? 0;
 		$tax_rates           = \WC_Tax::get_shipping_tax_rates();
 		$calculated_tax_rate = 0;
 
@@ -173,7 +172,11 @@ class Qliro_One_Shipping_Method extends WC_Shipping_Method {
 		}
 
 		foreach ( $tax_rates as $key => $tax_rate ) {
-			if ( $tax_rate['rate'] === $calculated_tax_rate ) {
+			// Calculate the difference between the rate and the calculated rate.
+			$diff = abs( $tax_rate['rate'] - $calculated_tax_rate );
+
+			// If the diff is less than or equal to 0.1 we have a match. This avoid rounding issues for tax rate calculations, and also covers the cases where the tax rates have decimals.
+			if ( $diff <= 0.1 ) {
 				return array( $key => $tax_rate );
 			}
 		}


### PR DESCRIPTION
…for integrated shipping

Fixes the tax rate match with WooCommerce in cases where the tax rate is not always calculated to match the WC rates exactly.

Example would be 12% tax, with a price inc vat of 69 will be returned by Qliro as `totalShippingPriceExVat` 61.6 and `totalShippingPrice` 69. Causing the calculated rate to be `11.99%` which will not match the WC rate of 12% directly. Allowing a diff of up to 0.1 will cover these cases and still allow for tax rates that include decimals. For example 25.5% for Finland.