### PR TITLE
Make sure settings exists & has fallback

### DIFF
--- a/classes/class-qliro-one-checkout.php
+++ b/classes/class-qliro-one-checkout.php
@@ -22,7 +22,7 @@ class Qliro_One_Checkout {
 	 * Class constructor
 	 */
 	public function __construct() {
-		$this->settings = get_option( 'woocommerce_qliro_one_settings' );
+		$this->settings = get_option( 'woocommerce_qliro_one_settings', array() );
 
 		add_filter( 'woocommerce_checkout_fields', array( $this, 'add_shipping_data_input' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'maybe_set_selected_pickup_point' ) );
@@ -200,7 +200,7 @@ class Qliro_One_Checkout {
 	 * @return bool
 	 */
 	public function is_shipping_in_iframe_enabled() {
-		return 'no' !== $this->settings['shipping_in_iframe'];
+		return isset( $this->settings['shipping_in_iframe'] ) && 'no' !== $this->settings['shipping_in_iframe'];
 	}
 
 	/**
@@ -209,7 +209,7 @@ class Qliro_One_Checkout {
 	 * @return bool
 	 */
 	public function is_integrated_shipping_enabled() {
-		return 'integrated_shipping' === $this->settings['shipping_in_iframe'];
+		return isset( $this->settings['shipping_in_iframe'] ) && 'integrated_shipping' === $this->settings['shipping_in_iframe'];
 	}
 
 	/**
@@ -218,6 +218,6 @@ class Qliro_One_Checkout {
 	 * @return bool
 	 */
 	public function is_wc_shipping_in_iframe_enabled() {
-		return 'wc_shipping' === $this->settings['shipping_in_iframe'];
+		return isset( $this->settings['shipping_in_iframe'] ) && 'wc_shipping' === $this->settings['shipping_in_iframe'];
 	}
 }


### PR DESCRIPTION
Make sure settings have an empty array as fallback if it does not exist, and check that needed array keys exists. This resolves the "array offset on value of type bool" warning, and avoids the "undefined array key" warning.

**Question: Should we be concerned with why the `woocommerce_qliro_one_settings` option is sometimes not defined for some customers?**