### PR TITLE
Fix issues with refunds

### DIFF
--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -227,7 +227,7 @@ class Qliro_One_Helper_Order {
 			// If the shipping method used is the qliro_shipping method, we should use the order line meta.
 			if ( 'qliro_shipping' === $order_item->get_method_id() ) {
 				// If this is a refund order line, we need to get the parent to ensure we get the correct shipping reference.
-				if ( $order_item->get_meta( '_refunded_item_id' ) ) {
+				if ( ! empty( $order_item->get_meta( '_refunded_item_id' ) ) ) {
 					$order_item = new WC_Order_Item_Shipping( $order_item->get_meta( '_refunded_item_id' ) );
 				}
 
@@ -250,7 +250,9 @@ class Qliro_One_Helper_Order {
 	 * @return string
 	 */
 	public static function get_unit_price_inc_vat( $order_item ) {
-		$unit_price = wc_format_decimal( ( $order_item->get_total() + $order_item->get_total_tax() ) / $order_item->get_quantity(), min( wc_get_price_decimals(), 2 ) );
+		$quantity = empty( $order_item->get_quantity() ) ? 1 : $order_item->get_quantity();
+
+		$unit_price = wc_format_decimal( ( $order_item->get_total() + $order_item->get_total_tax() ) / $quantity, min( wc_get_price_decimals(), 2 ) );
 		return $unit_price;
 	}
 
@@ -261,7 +263,9 @@ class Qliro_One_Helper_Order {
 	 * @return string
 	 */
 	public static function get_unit_price_ex_vat( $order_item ) {
-		$unit_price = wc_format_decimal( ( $order_item->get_total() ) / $order_item->get_quantity(), min( wc_get_price_decimals(), 2 ) );
+		$quantity = empty( $order_item->get_quantity() ) ? 1 : $order_item->get_quantity();
+
+		$unit_price = wc_format_decimal( ( $order_item->get_total() ) / $quantity, min( wc_get_price_decimals(), 2 ) );
 		return $unit_price;
 	}
 


### PR DESCRIPTION
* Fix - Fix issue with refunding a shipping line that has the shipping reference set in the order item meta data.
* Fix - Fix a division by zero issue when attempting to refund a order line without setting the quantity.

Fixes #86971fdhy and #865czngh4