### PR TITLE
Add check to make sure is not rest request

### DIFF
--- a/classes/class-qliro-one-api.php
+++ b/classes/class-qliro-one-api.php
@@ -180,7 +180,7 @@ class Qliro_One_API {
 	 */
 	private function check_for_api_error( $response ) {
 		if ( is_wp_error( $response ) ) {
-			if ( ! is_admin() ) {
+			if ( ! is_admin() && ! wp_is_serving_rest_request() ) {
 				qliro_one_print_error_message( $response );
 			}
 		}


### PR DESCRIPTION
Add check to make sure is not rest request, to avoid HTML errors being printed in request.

Tested and working with WP REST API through local ngrok environment.