### PR TITLE
Fetches missing address data from Qliro API during update

### DIFF
--- a/assets/js/qliro-one-for-woocommerce.js
+++ b/assets/js/qliro-one-for-woocommerce.js
@@ -1,8 +1,8 @@
 /**
  * @var qliroOneParams
  */
-jQuery( function( $ ) {
-	if ( typeof qliroOneParams === 'undefined' || qliroOneParams.isEnabled !== 'yes' ) {
+jQuery(function ($) {
+	if (typeof qliroOneParams === 'undefined' || qliroOneParams.isEnabled !== 'yes') {
 		return false;
 	}
 	var qliroOneForWooCommerce = {
@@ -13,42 +13,42 @@ jQuery( function( $ ) {
 		paymentMethodEl: $('input[name="payment_method"]'),
 
 		init: function () {
-			$( document ).ready( qliroOneForWooCommerce.documentReady );
-			qliroOneForWooCommerce.bodyEl.on( 'change', 'input[name="payment_method"]', qliroOneForWooCommerce.maybeChangeToQliroOne );
-			qliroOneForWooCommerce.bodyEl.on( 'click', qliroOneForWooCommerce.selectAnotherSelector, qliroOneForWooCommerce.changeFromQliroOne );
-			qliroOneForWooCommerce.bodyEl.on( 'updated_checkout', qliroOneForWooCommerce.maybeDisplayShippingPrice );
+			$(document).ready(qliroOneForWooCommerce.documentReady);
+			qliroOneForWooCommerce.bodyEl.on('change', 'input[name="payment_method"]', qliroOneForWooCommerce.maybeChangeToQliroOne);
+			qliroOneForWooCommerce.bodyEl.on('click', qliroOneForWooCommerce.selectAnotherSelector, qliroOneForWooCommerce.changeFromQliroOne);
+			qliroOneForWooCommerce.bodyEl.on('updated_checkout', qliroOneForWooCommerce.maybeDisplayShippingPrice);
 			qliroOneForWooCommerce.renderIframe();
 		},
 		/**
 		 * Triggers on document ready.
 		 */
-		documentReady: function() {
-			if ( 0 < $('input[name="payment_method"]').length ) {
-				qliroOneForWooCommerce.paymentMethod = $('input[name="payment_method"]').filter( ':checked' ).val();
+		documentReady: function () {
+			if (0 < $('input[name="payment_method"]').length) {
+				qliroOneForWooCommerce.paymentMethod = $('input[name="payment_method"]').filter(':checked').val();
 			} else {
 				qliroOneForWooCommerce.paymentMethod = 'qliro_one';
 			}
 
-			if( ! qliroOneParams.payForOrder && qliroOneForWooCommerce.paymentMethod === 'qliro_one' ) {
+			if (!qliroOneParams.payForOrder && qliroOneForWooCommerce.paymentMethod === 'qliro_one') {
 				qliroOneForWooCommerce.moveExtraCheckoutFields();
 			}
 			qliroOneForWooCommerce.bodyEl.on('update_checkout', qliroOneForWooCommerce.updateCheckout);
 			qliroOneForWooCommerce.bodyEl.on('updated_checkout', qliroOneForWooCommerce.updatedCheckout);
 		},
-		renderIframe: function() {
-			window.q1Ready = function(q1) {
+		renderIframe: function () {
+			window.q1Ready = function (q1) {
 				q1.onCustomerInfoChanged(qliroOneForWooCommerce.updateAddress);
 				q1.onValidateOrder(qliroOneForWooCommerce.placeWooOrder);
 				q1.onShippingMethodChanged(qliroOneForWooCommerce.shippingMethodChanged);
 			}
-			$('#qliro-one-iframe').append( qliroOneParams.iframeSnippet );
+			$('#qliro-one-iframe').append(qliroOneParams.iframeSnippet);
 		},
-		updateCheckout: function() {
+		updateCheckout: function () {
 			if (window.q1 !== undefined) {
 				window.q1.lock();
 			}
 		},
-		updatedCheckout: function() {
+		updatedCheckout: function () {
 			if (window.q1 !== undefined) {
 				window.q1.onOrderUpdated(function (order) {
 					window.q1.unlock();
@@ -57,16 +57,16 @@ jQuery( function( $ ) {
 		},
 		shippingMethodChanged: function (shipping) {
 			$('#qoc_shipping_data').val(JSON.stringify(shipping));
-			$( 'body' ).trigger( 'qoc_shipping_option_changed', [ shipping ]);
-			$( 'body' ).trigger( 'update_checkout' );
+			$('body').trigger('qoc_shipping_option_changed', [shipping]);
+			$('body').trigger('update_checkout');
 		},
 		/**
 		 * When the customer changes from Qliro One to other payment methods.
 		 * @param {Event} e
 		 */
-		changeFromQliroOne: function( e ) {
+		changeFromQliroOne: function (e) {
 			e.preventDefault();
-			$( qliroOneForWooCommerce.checkoutFormSelector ).block({
+			$(qliroOneForWooCommerce.checkoutFormSelector).block({
 				message: null,
 				overlayCSS: {
 					background: '#fff',
@@ -82,9 +82,9 @@ jQuery( function( $ ) {
 					nonce: qliroOneParams.change_payment_method_nonce
 				},
 				url: qliroOneParams.change_payment_method_url,
-				success: function( data ) {},
-				error: function( data ) {},
-				complete: function( data ) {
+				success: function (data) { },
+				error: function (data) { },
+				complete: function (data) {
 					window.location.href = data.responseJSON.data.redirect;
 				}
 			});
@@ -92,17 +92,18 @@ jQuery( function( $ ) {
 		/**
 		 * When the customer changes to Qliro One from other payment methods.
 		 */
-		maybeChangeToQliroOne: function() {
-			if ( ! qliroOneForWooCommerce.preventPaymentMethodChange ) {
-				if ( 'qliro_one' === $( this ).val() ) {
-					$( '.woocommerce-info' ).remove();
-					$( qliroOneForWooCommerce.checkoutFormSelector ).block({
+		maybeChangeToQliroOne: function () {
+			if (!qliroOneForWooCommerce.preventPaymentMethodChange) {
+				if ('qliro_one' === $(this).val()) {
+					$('.woocommerce-info').remove();
+					$(qliroOneForWooCommerce.checkoutFormSelector).block({
 						message: null,
 						overlayCSS: {
 							background: '#fff',
 							opacity: 0.6
 						}
 					});
+
 					$.ajax({
 						type: 'POST',
 						data: {
@@ -111,9 +112,9 @@ jQuery( function( $ ) {
 						},
 						dataType: 'json',
 						url: qliroOneParams.change_payment_method_url,
-						success: function( data ) {},
-						error: function( data ) {},
-						complete: function( data ) {
+						success: function (data) { },
+						error: function (data) { },
+						complete: function (data) {
 							window.location.href = data.responseJSON.data.redirect;
 						}
 					});
@@ -123,36 +124,36 @@ jQuery( function( $ ) {
 		/**
 		 * Display Shipping Price in order review if Display shipping methods in iframe settings is active.
 		 */
-		maybeDisplayShippingPrice: function() {
+		maybeDisplayShippingPrice: function () {
 			// Check if we already have set the price. If we have, return.
-			if( $('.qoc-shipping').length ) {
+			if ($('.qoc-shipping').length) {
 				return;
 			}
-			if ( 'qliro_one' === qliroOneForWooCommerce.paymentMethod && 'no' !== qliroOneParams.shipping_in_iframe ) {
-				if ( $( '#shipping_method input[type=\'radio\']' ).length ) {
+			if ('qliro_one' === qliroOneForWooCommerce.paymentMethod && 'no' !== qliroOneParams.shipping_in_iframe) {
+				if ($('#shipping_method input[type=\'radio\']').length) {
 					// Multiple shipping options available.
-					$( '#shipping_method input[type=\'radio\']:checked' ).each( function() {
-						var idVal = $( this ).attr( 'id' );
-						var shippingPrice = $( 'label[for=\'' + idVal + '\']' ).text();
-						$( '.woocommerce-shipping-totals td' ).html( shippingPrice );
-						$( '.woocommerce-shipping-totals td' ).addClass( 'qoc-shipping' );
+					$('#shipping_method input[type=\'radio\']:checked').each(function () {
+						var idVal = $(this).attr('id');
+						var shippingPrice = $('label[for=\'' + idVal + '\']').text();
+						$('.woocommerce-shipping-totals td').html(shippingPrice);
+						$('.woocommerce-shipping-totals td').addClass('qoc-shipping');
 					});
 				} else {
 					// Only one shipping option available.
-					var idVal = $( '#shipping_method input[name=\'shipping_method[0]\']' ).attr( 'id' );
-					var shippingPrice = $( 'label[for=\'' + idVal + '\']' ).text();
-					$( '.woocommerce-shipping-totals td' ).html( shippingPrice );
-					$( '.woocommerce-shipping-totals td' ).addClass( 'qoc-shipping' );
+					var idVal = $('#shipping_method input[name=\'shipping_method[0]\']').attr('id');
+					var shippingPrice = $('label[for=\'' + idVal + '\']').text();
+					$('.woocommerce-shipping-totals td').html(shippingPrice);
+					$('.woocommerce-shipping-totals td').addClass('qoc-shipping');
 				}
 			}
 		},
 		/*
 		 * Check if Qliro One is the selected gateway.
 		 */
-		checkIfQliroOneSelected: function() {
+		checkIfQliroOneSelected: function () {
 			if (qliroOneForWooCommerce.paymentMethodEl.length > 0) {
 				qliroOneForWooCommerce.paymentMethod = qliroOneForWooCommerce.paymentMethodEl.filter(':checked').val();
-				if( 'qliro_one' === qliroOneForWooCommerce.paymentMethod ) {
+				if ('qliro_one' === qliroOneForWooCommerce.paymentMethod) {
 					return true;
 				}
 			}
@@ -161,68 +162,99 @@ jQuery( function( $ ) {
 		/**
 		 * Moves all non standard fields to the extra checkout fields.
 		 */
-		moveExtraCheckoutFields: function() {
+		moveExtraCheckoutFields: function () {
 			// Move order comments.
 			$('.woocommerce-additional-fields').appendTo('#qliro-one-extra-checkout-fields');
 
 			let form = $('form[name="checkout"] input, form[name="checkout"] select, textarea');
-			for (var i = 0; i < form.length; i++ ) {
+			for (var i = 0; i < form.length; i++) {
 				let name = form[i].name;
 				// Check if field is inside the order review.
-				if( $( 'table.woocommerce-checkout-review-order-table' ).find( form[i] ).length ) {
+				if ($('table.woocommerce-checkout-review-order-table').find(form[i]).length) {
 					continue;
 				}
 
 				// Check if this is a standard field.
-				if ( -1 === $.inArray( name, qliroOneParams.standardWooCheckoutFields ) ) {
+				if (-1 === $.inArray(name, qliroOneParams.standardWooCheckoutFields)) {
 					// This is not a standard Woo field, move to our div.
-					if ( 0 < $( 'p#' + name + '_field' ).length ) {
-						$( 'p#' + name + '_field' ).appendTo( '#qliro-one-extra-checkout-fields' );
+					if (0 < $('p#' + name + '_field').length) {
+						$('p#' + name + '_field').appendTo('#qliro-one-extra-checkout-fields');
 					} else {
-						$( 'input[name="' + name + '"]' ).closest( 'p' ).appendTo( '#qliro-one-extra-checkout-fields' );
+						$('input[name="' + name + '"]').closest('p').appendTo('#qliro-one-extra-checkout-fields');
 					}
 				}
 			}
 		},
-		updateAddress: function (customerInfo) {
-			var email = (('email' in customerInfo) ? customerInfo.email : null);
-			var phone = (('mobileNumber' in customerInfo) ? customerInfo.mobileNumber : null);
+		updateAddress: async (customerInfo) => {
+			// Since the postal code is not always included in the frontend, we need to fetch the address from the backend.
+			let billingAddress, shippingAddress, customer
+			try {
+				const response = await $.ajax({
+					type: 'POST',
+					data: {
+						nonce: qliroOneParams.get_order_nonce,
+					},
+					dataType: 'json',
+					url: qliroOneParams.get_order_url,
+				});
+
+				if (!response.success) {
+					throw 'Failed to GET address';
+				}
+
+				const { data } = response;
+				billingAddress = data.billingAddress;
+				shippingAddress = data.shippingAddress;
+				customer = data.customer;
+
+			} catch (error) {
+				console.warning(error);
+				window.location.reload();
+			}
+
+			const firstName = billingAddress?.FirstName ?? customerInfo?.address?.firstName;
+			const lastName = billingAddress?.LastName ?? customerInfo?.address?.lastName;
+			const street = billingAddress?.Street ?? customerInfo?.address?.street;
+			const postalCode = billingAddress?.PostalCode ?? customerInfo?.address?.postalCode;
+			const city = billingAddress?.City ?? customerInfo?.address?.city;
+			const area = billingAddress?.Area ?? customerInfo?.address?.area;
+			const phone = customer?.MobileNumber ?? customerInfo?.mobileNumber;
+			const email = customer?.Email ?? customerInfo?.email;
 
 			qliroOneForWooCommerce.setCustomerType(customerInfo);
 
-			var firstName, lastName, street, postalCode, city, area;
-			if (customerInfo.address) {
-				firstName = (('firstName' in customerInfo.address) ? customerInfo.address.firstName : null);
-				lastName = (('lastName' in customerInfo.address) ? customerInfo.address.lastName : null);
-				street = (('street' in customerInfo.address) ? street : null);
-				postalCode = (('postalCode' in customerInfo.address) ? customerInfo.address.postalCode : null);
-				city = (('city' in customerInfo.address) ? customerInfo.address.city : null);
-				area = (('area' in customerInfo.address) ? customerInfo.address.area : null);
-			}
-
 			// Check if shipping fields or billing fields are to be used.
 			if (!$('#ship-to-different-address-checkbox').is(":checked")) {
-				(email !== null && email !== undefined) ? $('#billing_email').val(email) : null;
-				(phone !== null && phone !== undefined) ? $('#billing_phone').val(phone) : null;
-				(firstName !== null && firstName !== undefined) ? $('#billing_first_name').val(firstName) : null;
-				(lastName !== null && lastName !== undefined) ? $('#billing_last_name').val(lastName) : null;
-				(street !== null && street !== undefined) ? $('#billing_address_1').val(street) : null;
-				(postalCode !== null && postalCode !== undefined) ? $('#billing_postcode').val(postalCode) : null;
-				(city !== null && city !== undefined) ? $('#billing_city').val(city) : null;
-				(area !== null && area !== undefined) ? qliroOneForWooCommerce.setStateField( 'billing', area ) : null;
+				(email == null) ? null : $('#billing_email').val(email);
+				(phone == null) ? null : $('#billing_phone').val(phone);
+				(firstName == null) ? null : $('#billing_first_name').val(firstName);
+				(lastName == null) ? null : $('#billing_last_name').val(lastName);
+				(street == null) ? null : $('#billing_address_1').val(street);
+				(postalCode == null) ? null : $('#billing_postcode').val(postalCode);
+				(city == null) ? null : $('#billing_city').val(city);
+				(area == null) ? null : qliroOneForWooCommerce.setStateField('billing', area);
+
 				$("form.checkout").trigger('update_checkout');
 				$('#billing_email').change();
 				$('#billing_email').blur();
 			} else {
-				(email !== null && email !== undefined) ? $('#shipping_email').val(email) : null;
-				(phone !== null && phone !== undefined) ? $('#shipping_phone').val(phone) : null;
-				(firstName !== null && firstName !== undefined) ? $('#shipping_first_name').val(firstName) : null;
-				(lastName !== null && lastName !== undefined) ? $('#shipping_last_name').val(lastName) : null;
-				(street !== null && street !== undefined) ? $('#shipping_address_1').val(street) : null;
-				(postalCode !== null && postalCode !== undefined) ? $('#shipping_postcode').val(postalCode) : null;
-				(city !== null && city !== undefined) ? $('#shipping_city').val(city) : null;
-				(area !== null && area !== undefined) ? qliroOneForWooCommerce.setStateField("shipping", area) : null;
-				$("form.checkout").trigger('update_checkout');
+				const shippingFirstName = shippingAddress?.FirstName ?? customerInfo?.address?.firstName;
+				const shippingLastName = shippingAddress?.LastName ?? customerInfo?.address?.lastName;
+				const shippingStreet = shippingAddress?.Street ?? customerInfo?.address?.street;
+				const shippingPostalCode = shippingAddress?.PostalCode ?? customerInfo?.address?.postalCode;
+				const shippingCity = shippingAddress?.City ?? customerInfo?.address?.city;
+				const shippingArea = shippingAddress?.Area ?? customerInfo?.address?.area;
+
+				(email == null) ? null : $('#shipping_email').val(email);
+				(phone == null) ? null : $('#shipping_phone').val(phone);
+				(shippingFirstName == null) ? null : $('#shipping_first_name').val(shippingFirstName);
+				(shippingLastName == null) ? null : $('#shipping_last_name').val(shippingLastName);
+				(shippingStreet == null) ? null : $('#shipping_address_1').val(shippingStreet);
+				(shippingPostalCode == null) ? null : $('#shipping_postcode').val(shippingPostalCode);
+				(shippingCity == null) ? null : $('#shipping_city').val(shippingCity);
+				(shippingArea == null) ? null : qliroOneForWooCommerce.setStateField("shipping", shippingArea);
+
+				$('body').trigger('update_checkout');
 				$('#shipping_email').change();
 				$('#shipping_email').blur();
 			}
@@ -232,7 +264,7 @@ jQuery( function( $ ) {
 		 * Sets the customer type in the cookie.
 		 */
 		setCustomerType: function (customerInfo) {
-			if (customerInfo.organizationNumber ) {
+			if (customerInfo.organizationNumber) {
 				// Business customer.
 				Cookies.set(qliroOneParams.customerTypeCookieName, 'business');
 			} else {
@@ -242,7 +274,7 @@ jQuery( function( $ ) {
 		},
 
 		getQliroOneOrder: function (data, callback) {
-			qliroOneForWooCommerce.logToFile( 'onValidateOrder from Qliro triggered' );
+			qliroOneForWooCommerce.logToFile('onValidateOrder from Qliro triggered');
 			$.ajax({
 				type: 'POST',
 				data: {
@@ -273,7 +305,7 @@ jQuery( function( $ ) {
 			if (0 < $('form.checkout #terms').length) {
 				$('form.checkout #terms').prop('checked', true);
 			}
-			console.log( addressData );
+			console.log(addressData);
 
 			// Billing fields.
 			$('#billing_first_name').val(addressData.billingAddress.FirstName);
@@ -288,7 +320,7 @@ jQuery( function( $ ) {
 			$('#billing_email').val(addressData.customer.Email);
 
 			// Shipping fields.
-			$('#ship-to-different-address-checkbox').prop( 'checked', true);
+			$('#ship-to-different-address-checkbox').prop('checked', true);
 			$('#shipping_first_name').val(addressData.shippingAddress.FirstName);
 			$('#shipping_last_name').val(addressData.shippingAddress.LastName);
 			$('#shipping_company').val(addressData.shippingAddress.CompanyName);
@@ -366,11 +398,11 @@ jQuery( function( $ ) {
 					try {
 						if ('success' === data.result) {
 							console.log('submit order success', data);
-							qliroOneForWooCommerce.logToFile( 'Successfully placed order. Sending "shouldProceed: true" to Qliro.' );
-							callback({shouldProceed: true, errorMessage: ""});
+							qliroOneForWooCommerce.logToFile('Successfully placed order. Sending "shouldProceed: true" to Qliro.');
+							callback({ shouldProceed: true, errorMessage: "" });
 
 							// Remove the timeout.
-							clearTimeout( qliroOneForWooCommerce.timeout );
+							clearTimeout(qliroOneForWooCommerce.timeout);
 
 						} else {
 							console.log('submit order - missing success', data);
@@ -383,53 +415,53 @@ jQuery( function( $ ) {
 							// Strip HTML code from messages.
 							let messages = data.messages.replace(/<\/?[^>]+(>|$)/g, "");
 							console.log('error ', messages);
-							qliroOneForWooCommerce.logToFile( 'Checkout error | ' + messages );
-							qliroOneForWooCommerce.failOrder( 'submission', messages, callback );
+							qliroOneForWooCommerce.logToFile('Checkout error | ' + messages);
+							qliroOneForWooCommerce.failOrder('submission', messages, callback);
 						} else {
-							qliroOneForWooCommerce.logToFile( 'Checkout error | No message' );
-							qliroOneForWooCommerce.failOrder( 'submission', 'Checkout error', callback );
+							qliroOneForWooCommerce.logToFile('Checkout error | No message');
+							qliroOneForWooCommerce.failOrder('submission', 'Checkout error', callback);
 						}
 					}
 				},
 				error: function (data) {
 					try {
-						qliroOneForWooCommerce.logToFile( 'AJAX error | ' + JSON.stringify(data) );
-					} catch( e ) {
-						qliroOneForWooCommerce.logToFile( 'AJAX error | Failed to parse error message.' );
+						qliroOneForWooCommerce.logToFile('AJAX error | ' + JSON.stringify(data));
+					} catch (e) {
+						qliroOneForWooCommerce.logToFile('AJAX error | Failed to parse error message.');
 					}
-					qliroOneForWooCommerce.failOrder( 'ajax-error', 'Internal Server Error', callback )
+					qliroOneForWooCommerce.failOrder('ajax-error', 'Internal Server Error', callback)
 				}
 			});
 		},
-		failOrder: function( event, error_message, callback ) {
+		failOrder: function (event, error_message, callback) {
 
 			// Remove the timeout.
-			clearTimeout( qliroOneForWooCommerce.timeout );
+			clearTimeout(qliroOneForWooCommerce.timeout);
 
-			callback({shouldProceed: false, errorMessage: error_message});
+			callback({ shouldProceed: false, errorMessage: error_message });
 
 			// Re-enable the form.
-			$( 'body' ).trigger( 'updated_checkout' );
+			$('body').trigger('updated_checkout');
 			var className = 'form.checkout';
-			$( qliroOneForWooCommerce.checkoutFormSelector ).removeClass( 'processing' );
-			$( qliroOneForWooCommerce.checkoutFormSelector ).unblock();
-			$( '.woocommerce-checkout-review-order-table' ).unblock();
+			$(qliroOneForWooCommerce.checkoutFormSelector).removeClass('processing');
+			$(qliroOneForWooCommerce.checkoutFormSelector).unblock();
+			$('.woocommerce-checkout-review-order-table').unblock();
 		},
 
-		placeWooOrder: function( data, callback ) {
-			qliroOneForWooCommerce.timeout = setTimeout( () => {
-				qliroOneForWooCommerce.logToFile( 'Timeout error | Timeout when placing the WooCommerce order' );
-				qliroOneForWooCommerce.failOrder( 'timeout-error', 'Timeout error', callback );
-			}, 29000 ); // 29 seconds.
+		placeWooOrder: function (data, callback) {
+			qliroOneForWooCommerce.timeout = setTimeout(() => {
+				qliroOneForWooCommerce.logToFile('Timeout error | Timeout when placing the WooCommerce order');
+				qliroOneForWooCommerce.failOrder('timeout-error', 'Timeout error', callback);
+			}, 29000); // 29 seconds.
 
-			qliroOneForWooCommerce.getQliroOneOrder( data, callback );
+			qliroOneForWooCommerce.getQliroOneOrder(data, callback);
 
 		},
 		/**
 		 * Logs the message to the Qliro checkout log in WooCommerce.
 		 * @param {string} message
 		 */
-		logToFile: function( message ) {
+		logToFile: function (message) {
 			$.ajax(
 				{
 					url: qliroOneParams.log_to_file_url,


### PR DESCRIPTION
 Since the postal code is not always included in the frontend, we need to fetch the address from the backend. Changes were only done in the `updateAddress` functions, all other changes concern formatting by VSCode. I wanted to install wp-prettier to keep consistent formatting, but I didn't want this PR to be filled with red and green lines.

https://app.clickup.com/t/8697p4z3v