### PR TITLE
Remove Type in Capture

### DIFF
--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -202,7 +202,6 @@ class Qliro_One_Helper_Order {
 			'MerchantReference'  => self::get_reference( $order_item ),
 			'Description'        => $order_item->get_name(),
 			'Quantity'           => 1,
-			'Type'               => 'Fee',
 			'PricePerItemIncVat' => self::get_unit_price_inc_vat( $order_item ),
 			'PricePerItemExVat'  => self::get_unit_price_ex_vat( $order_item ),
 		);


### PR DESCRIPTION
Fee's have no Type upon creation, making Qliro responsible for determining which Type is suitable. This PR makes this behaviour consistent with the Capture.

Can not find any tests - there's one that tries to find KCO which will always fail.