### PR TITLE
Get parent shipping reference when needed

### DIFF
--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -227,6 +227,11 @@ class Qliro_One_Helper_Order {
 			$order              = wc_get_order( $order_item->get_order_id() );
 			$shipping_reference = ! empty( $order ) ? $order->get_meta( '_qliro_one_shipping_reference' ) : '';
 
+			if ( empty( $shipping_reference ) && $order->get_parent_id() ) {
+				$parent_order       = wc_get_order( $order->get_parent_id() );
+				$shipping_reference = $parent_order ? $parent_order->get_meta( '_qliro_one_shipping_reference' ) : '';
+			}
+
 			// If the shipping method used is the qliro_shipping method, we should use the order line meta.
 			if ( 'qliro_shipping' === $order_item->get_method_id() ) {
 				// If this is a refund order line, we need to get the parent to ensure we get the correct shipping reference.


### PR DESCRIPTION
Get `_qliro_one_shipping_reference` meta from parent order, when none is found for shipping order item. This seems to be needed when attempting refunds on KSC shipping order items. Not sure if this is the correct solution, but it resolves this particular issue.