### PR TITLE
Add coupons to the order hash

### DIFF
--- a/classes/class-qliro-one-checkout.php
+++ b/classes/class-qliro-one-checkout.php
@@ -170,9 +170,9 @@ class Qliro_One_Checkout {
 		$billing_address  = WC()->customer->get_billing();
 		$shipping_address = WC()->customer->get_shipping();
 		$shipping_method  = WC()->session->get( 'chosen_shipping_methods' );
-
+		$coupon_code      = WC()->cart->applied_coupons ? implode( ',', WC()->cart->applied_coupons ) : '';
 		// Calculate a hash from the values.
-		$hash = md5( wp_json_encode( array( $total, $billing_address, $shipping_address, $shipping_method ) ) );
+		$hash = md5( wp_json_encode( array( $total, $billing_address, $shipping_address, $shipping_method, $coupon_code ) ) );
 
 		return $hash;
 	}


### PR DESCRIPTION
Adds any applied coupons to the order hash, to detect changes even when the coupon does not add a discount to order items (like for free shipping).