### PR TITLE
If no vouchers are applied, send empty voucher

### DIFF
--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -348,6 +348,15 @@ class Qliro_One_Helper_Cart {
 	 * @return void
 	 */
 	private static function set_ingrid_vouchers( &$metadata ) {
+		// If no coupons are applied, add an empty voucher to trigger an update of the Qliro shipping options.
+		if ( empty( WC()->cart->get_applied_coupons() ) ) {
+			$metadata[] = array(
+				'Key'   => 'Ingrid.Vouchers',
+				'Value' => '',
+			);
+			return;
+		}
+
 		foreach ( WC()->cart->get_applied_coupons() as $coupon ) {
 			$metadata[] = array(
 				'Key'   => 'Ingrid.Vouchers',


### PR DESCRIPTION
If no vouchers are applied, include empty voucher to meta, to still trigger an update of the Qliro shipping options.