### PR TITLE
Add fallback to base location

### DIFF
--- a/classes/requests/post/class-qliro-one-request-create-order.php
+++ b/classes/requests/post/class-qliro-one-request-create-order.php
@@ -63,8 +63,7 @@ class Qliro_One_Request_Create_Order extends Qliro_One_Request_Post {
 		$mer_ref       = null;
 		$session       = WC()->session;
 
-		$base_location   = wc_get_base_location();
-		$billing_country = apply_filters( 'qliro_one_billing_country', WC()->checkout()->get_value( 'billing_country' ) ?? $base_location['country'] );
+		$billing_country = qliro_one_get_billing_country();
 		$session->set( 'qliro_one_billing_country', $billing_country );
 
 		// Merchant reference.

--- a/includes/qliro-one-functions.php
+++ b/includes/qliro-one-functions.php
@@ -588,3 +588,13 @@ function qliro_one_redirect_to_thankyou_page() {
 	wp_safe_redirect( $redirect_url );
 	exit;
 }
+
+/**
+ * Get the billing country from the checkout, or the store base location if not set.
+ *
+ * @return string
+ */
+function qliro_one_get_billing_country() {
+	$base_location = wc_get_base_location();
+	return apply_filters( 'qliro_one_billing_country', WC()->checkout()->get_value( 'billing_country' ) ?? $base_location['country'] );
+}


### PR DESCRIPTION
Add fallback for billing country to base location Country: null, when `WC()->checkout()->get_value( 'billing_country' )` is not yet set in checkout.