### PR TITLE
Limit character length for frontend log messages

### DIFF
--- a/classes/class-qliro-one-ajax.php
+++ b/classes/class-qliro-one-ajax.php
@@ -105,10 +105,18 @@ class Qliro_One_Ajax extends WC_AJAX {
 	 * @return void
 	 */
 	public static function qliro_one_wc_log_js() {
-		$nonce = isset( $_POST['nonce'] ) ? sanitize_key( $_POST['nonce'] ) : '';
-		if ( ! wp_verify_nonce( $nonce, 'qliro_one_wc_log_js' ) ) {
-			wp_send_json_error( 'bad_nonce' );
+		check_ajax_referer( 'qliro_one_wc_log_js', 'nonce' );
+		$qliro_order_id = WC()->session->get( 'qliro_one_order_id' );
+
+		// Get the content size of the request.
+		$post_size = (int) $_SERVER['CONTENT_LENGTH'] ?? 0;
+
+		// If the post data is too long, log an error message and return.
+		if ( $post_size > 1024 ) {
+			Qliro_One_Logger::log( "Frontend JS $qliro_order_id: message too long and can't be logged." );
+			wp_send_json_success(); // Return success to not stop anything in the frontend if this happens.
 		}
+
 		$posted_message = isset( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
 		$message        = "Frontend JS $posted_message";
 		Qliro_One_Logger::log( $message );


### PR DESCRIPTION
Limit the max size of a log message from the frontend to 1000 characters to prevent large logs from being created.