### PR TITLE
Include cart hash in the update check hash

### DIFF
--- a/classes/class-qliro-one-checkout.php
+++ b/classes/class-qliro-one-checkout.php
@@ -171,8 +171,10 @@ class Qliro_One_Checkout {
 		$shipping_address = WC()->customer->get_shipping();
 		$shipping_method  = WC()->session->get( 'chosen_shipping_methods' );
 		$coupon_code      = WC()->cart->applied_coupons ? implode( ',', WC()->cart->applied_coupons ) : '';
+		$cart_hash        = WC()->cart->get_cart_hash();
+
 		// Calculate a hash from the values.
-		$hash = md5( wp_json_encode( array( $total, $billing_address, $shipping_address, $shipping_method, $coupon_code ) ) );
+		$hash = md5( wp_json_encode( array( $total, $billing_address, $shipping_address, $shipping_method, $coupon_code, $cart_hash ) ) );
 
 		return $hash;
 	}


### PR DESCRIPTION
* Fix - Include cart hash when testing if we need to update a Qliro session or not to catch changes that effects products but not the order total.