### PR TITLE
Log errors when wp_remote_request returns a WP_Error directly

### DIFF
--- a/classes/requests/class-qliro-one-request.php
+++ b/classes/requests/class-qliro-one-request.php
@@ -157,6 +157,7 @@ abstract class Qliro_One_Request {
 	 */
 	protected function process_response( $response, $request_args, $request_url ) {
 		if ( is_wp_error( $response ) ) {
+			$this->log_response( $response, $request_args, $request_url );
 			return $response;
 		}
 


### PR DESCRIPTION
In some cases `wp_remote_request` can return a `WP_Error` directly, for example if the site cant be reached or bad SSL certificates. Currently we do not log that properly, and could potentially miss this in our support. This adds logging for that case, so the error is logged properly.