### PR TITLE
Sets button default text if refund amount is 0

### DIFF
--- a/assets/js/admin-order.js
+++ b/assets/js/admin-order.js
@@ -263,7 +263,8 @@ jQuery(function ($) {
 
 			const refundFeeAmount = qoc.unformat_number($qliroReturnFeeAmountField.val()) + qoc.unformat_number($qliroReturnFeeTaxAmountField.val());
 
-			if( refundFeeAmount === 0 ) {
+			if (refundFeeAmount === 0) {
+				$qliroReturnFeeTotalSpan.text('');
 				return;
 			}
 


### PR DESCRIPTION
Currently, we add append a refund fee text to the WC refund button. However, it doesn't take zero amount into consideration.

- removes the refund fee text if refund amount is zero.

https://app.clickup.com/t/86994kz1h