### PR TITLE
Make exceptions compatible with PHP 7

### DIFF
--- a/classes/api/notifications/class-qliro-one-notifications-ingrid-shipping.php
+++ b/classes/api/notifications/class-qliro-one-notifications-ingrid-shipping.php
@@ -40,8 +40,15 @@ class Qliro_One_Notifications_Ingrid_Shipping extends Qliro_One_Notifications {
 			throw new WP_Exception( 'Order not found in WooCommerce.', 404 );
 		}
 
-		$session         = $payload['session'] ?? throw new WP_Exception( 'Session data is missing from the payload.', 401 );
-		$delivery_groups = $session['delivery_groups'] ?? throw new WP_Exception( 'Delivery groups data is missing from the session data.', 401 );
+		if ( ! isset( $payload['session'] ) ) {
+			throw new WP_Exception( 'Session data is missing from the payload.', 401 );
+		}
+		$session = $payload['session'];
+
+		if ( ! isset( $session['delivery_groups'] ) ) {
+			throw new WP_Exception( 'Delivery groups data is missing from the session data.', 401 );
+		}
+		$delivery_groups = $session['delivery_groups'];
 
 		// From the first delivery group, get the tos_id.
 		if ( empty( $delivery_groups ) || ! isset( $delivery_groups[0]['tos_id'] ) ) {


### PR DESCRIPTION
After some research, it seems that the `throw` expression can only be used along with the coalescing operator in PHP 8+?

Tested and works; not sure if it should be solved in a neater way.