### PR TITLE
Call payment complete after setting meta data

### DIFF
--- a/classes/class-qliro-one-subscriptions.php
+++ b/classes/class-qliro-one-subscriptions.php
@@ -61,9 +61,6 @@ class Qliro_One_Subscriptions {
 			return;
 		}
 
-		// If the result is not a WP_Error, complete the payment.
-		$subscription->payment_complete( $result['OrderId'] );
-
 		// Set the required order meta for the renewal order.
 		$order->add_meta_data( '_qliro_payment_transaction_id', $result['PaymentTransactions'][0]['PaymentTransactionId'], true );
 		$order->add_meta_data( '_qliro_one_order_id', $result['OrderId'], true );
@@ -78,6 +75,9 @@ class Qliro_One_Subscriptions {
 			)
 		);
 		$order->save();
+
+		// If the result is not a WP_Error, complete the payment.
+		$subscription->payment_complete( $result['OrderId'] );
 	}
 
 	/**
@@ -108,9 +108,6 @@ class Qliro_One_Subscriptions {
 			return;
 		}
 
-		// If the result is not a WP_Error, complete the payment.
-		$subscription->payment_complete( $result['OrderId'] );
-
 		// Set the required order meta for the renewal order.
 		$order->add_meta_data( '_qliro_payment_transaction_id', $result['PaymentTransactions'][0]['PaymentTransactionId'], true );
 		$order->add_meta_data( '_qliro_one_order_id', $result['OrderId'], true );
@@ -125,6 +122,9 @@ class Qliro_One_Subscriptions {
 			)
 		);
 		$order->save();
+
+		// If the result is not a WP_Error, complete the payment.
+		$subscription->payment_complete( $result['OrderId'] );
 	}
 
 	/**


### PR DESCRIPTION
Call payment complete after setting meta data, to avoid error: "The order failed to be captured with Qliro: Property: OrderId, Message: Error converting value “” to type ‘System.Int64’. Path ‘OrderId’, line 1, position 89.. Order status changed from Completed to On hold."