### PR TITLE
Add exit back

### DIFF
--- a/classes/class-qliro-one-metabox.php
+++ b/classes/class-qliro-one-metabox.php
@@ -169,6 +169,7 @@ class Qliro_One_Metabox extends OrderMetabox {
 		Qliro_One_Order_Management::sync_order_with_qliro( $order_id, $qliro_order_id );
 
 		wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'edit.php?post_type=shop_order' ) );
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
Add "exit" back, Avoid being redirected to an empty page with a "0" printed when the order sync button is clicked.