### PR TITLE
Add the option of a custom shipping fee merchant reference

### DIFF
--- a/.changelogs/2026-02-26-shipping-fee-merchant-ref
+++ b/.changelogs/2026-02-26-shipping-fee-merchant-ref
@@ -1,0 +1,4 @@
+Type: Feature
+Needs Documentation: yes
+
+Added a shipping method setting together with the 'qliro_one_shipping_fee_merchant_reference' filter, to enable sending a custom ShippingFeeMerchantReference value to Qliro. Defaults to the shipping method's id.

--- a/classes/class-qliro-one-shipping-method-instance.php
+++ b/classes/class-qliro-one-shipping-method-instance.php
@@ -41,13 +41,13 @@ class Qliro_One_Shipping_Method_Instance {
 	 */
 	public function add_shipping_method_fields( $shipping_method_fields ) {
 		$settings_fields = array(
-			'qliro_shipping_settings'     => array(
+			'qliro_shipping_settings'               => array(
 				'title'       => __( 'Qliro shipping settings', 'qliro-for-woocommerce' ),
 				'type'        => 'title',
 				'description' => __( 'These settings let you customize the shipping methods in Qliro checkout, and only apply when you show the shipping options in the iframe. ', 'qliro-for-woocommerce' ),
 				'default'     => '',
 			),
-			'qliro_description'           => array(
+			'qliro_description'                     => array(
 				'title'       => __( 'Description', 'qliro-for-woocommerce' ),
 				'type'        => 'textarea',
 				'default'     => '',
@@ -55,7 +55,14 @@ class Qliro_One_Shipping_Method_Instance {
 				'placeholder' => __( 'Maximum length is 100 characters per line and up to 3 lines.', 'qliro-for-woocommerce' ),
 				'desc_tip'    => true,
 			),
-			'qliro_delivery_date_start'   => array(
+			'qliro_shipping_fee_merchant_reference' => array(
+				'title'       => __( 'Shipping fee merchant reference', 'qliro-for-woocommerce' ),
+				'type'        => 'text',
+				'default'     => '',
+				'description' => __( 'Custom value sent as ShippingFeeMerchantReference for this shipping method.', 'qliro-for-woocommerce' ),
+				'desc_tip'    => true,
+			),
+			'qliro_delivery_date_start'             => array(
 				'title'   => __( 'Delivery start date', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -73,7 +80,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'10'   => __( 'In 10 days', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_delivery_date_end'     => array(
+			'qliro_delivery_date_end'               => array(
 				'title'   => __( 'Delivery end date', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -91,7 +98,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'10'   => __( 'In 10 days', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_category_display_name' => array(
+			'qliro_category_display_name'           => array(
 				'title'   => __( 'Category Display Name', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -101,7 +108,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'PICKUP'        => __( 'Pickup Point', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_label_display_name'    => array(
+			'qliro_label_display_name'              => array(
 				'title'   => __( 'Label Display Name', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -112,7 +119,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'free'    => __( 'Free', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_brand'                 => array(
+			'qliro_brand'                           => array(
 				'title'       => __( 'Brand', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -141,7 +148,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'Ups'         => 'UPS',
 				),
 			),
-			'qliro_option_label_eco'      => array(
+			'qliro_option_label_eco'                => array(
 				'title'       => __( 'ECO friendly label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -154,7 +161,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_express'  => array(
+			'qliro_option_label_express'            => array(
 				'title'       => __( 'Express shipping label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -167,7 +174,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_evening'  => array(
+			'qliro_option_label_evening'            => array(
 				'title'       => __( 'Evening delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -180,7 +187,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_morning'  => array(
+			'qliro_option_label_morning'            => array(
 				'title'       => __( 'Morning delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -193,7 +200,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_home'     => array(
+			'qliro_option_label_home'               => array(
 				'title'       => __( 'Home delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -205,7 +212,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_box'      => array(
+			'qliro_option_label_box'                => array(
 				'title'       => __( 'Box delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -217,7 +224,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_pickup'   => array(
+			'qliro_option_label_pickup'             => array(
 				'title'       => __( 'Pickup label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -229,7 +236,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'tax_status'                  => array(
+			'tax_status'                            => array(
 				'title'   => __( 'Tax status', 'woocommerce' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 				'type'    => 'select',
 				'class'   => 'wc-enhanced-select',

--- a/classes/class-qliro-one-shipping-method-instance.php
+++ b/classes/class-qliro-one-shipping-method-instance.php
@@ -243,7 +243,7 @@ class Qliro_One_Shipping_Method_Instance {
 				'default' => 'taxable',
 				'options' => array(
 					'taxable' => __( 'Taxable', 'woocommerce' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
-					// 'none'    => _x( 'None', 'Tax status', 'woocommerce' ), @todo Implement logic for this.
+					// 'none'    => _x( 'None', 'Tax status', 'woocommerce' ), @todo Implement logic for this. // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 				),
 			),
 		);

--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -196,8 +196,10 @@ class Qliro_One_Helper_Cart {
 				$method_cost = qliro_ensure_numeric( $method->cost );
 
 				if ( $chosen_shipping === $method->id ) {
+					$shipping_fee_merchant_reference = self::get_shipping_fee_merchant_reference_from_rate( $method );
+
 					if ( $method_cost > 0 ) {
-						return array(
+						$shipping = array(
 							'MerchantReference'  => $method->get_id(),
 							'Description'        => $method->get_label(),
 							'Type'               => 'Shipping',
@@ -206,9 +208,15 @@ class Qliro_One_Helper_Cart {
 							'PricePerItemExVat'  => wc_format_decimal( WC()->cart->get_shipping_total(), min( wc_get_price_decimals(), 2 ) ),
 							'VatRate'            => self::get_shipping_tax_rate( $method ),
 						);
+
+						if ( ! empty( $shipping_fee_merchant_reference ) ) {
+							$shipping['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+						}
+
+						return $shipping;
 					}
 
-					return array(
+					$shipping = array(
 						'MerchantReference'  => $method->get_id(),
 						'Description'        => $method->get_label(),
 						'Type'               => 'Shipping',
@@ -217,11 +225,35 @@ class Qliro_One_Helper_Cart {
 						'PricePerItemExVat'  => 0,
 						'VatRate'            => self::format_vat_rate( 0 ),
 					);
+
+					if ( ! empty( $shipping_fee_merchant_reference ) ) {
+						$shipping['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+					}
+
+					return $shipping;
 				}
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get shipping fee merchant reference for the shipping rate.
+	 *
+	 * @param WC_Shipping_Rate $method The shipping method rate from WooCommerce.
+	 * @return string
+	 */
+	private static function get_shipping_fee_merchant_reference_from_rate( $method ) {
+		$method_id       = $method->get_id();
+		$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
+
+		$shipping_fee_merchant_reference = $method_settings['qliro_shipping_fee_merchant_reference'] ?? '';
+		$shipping_fee_merchant_reference = '' !== $shipping_fee_merchant_reference
+			? $shipping_fee_merchant_reference
+			: $method_id;
+
+		return sanitize_text_field( apply_filters( 'qliro_one_shipping_fee_merchant_reference', $shipping_fee_merchant_reference, $method, $method_settings ) );
 	}
 
 	/**

--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -41,7 +41,7 @@ class Qliro_One_Helper_Cart {
 		/**
 		 * Get cart fees.
 		 *
-		 * @var $cart_fees WC_Cart_Fees
+		 * @var array<WC_Cart_Fee> $cart_fees
 		 */
 		$cart_fees = WC()->cart->get_fees();
 		foreach ( $cart_fees as $fee ) {
@@ -190,8 +190,12 @@ class Qliro_One_Helper_Cart {
 		$packages        = WC()->shipping()->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 		$chosen_shipping = $chosen_methods[0];
-		foreach ( $packages as $i => $package ) {
-			/** @var WC_Shipping_Rate $method */
+		foreach ( $packages as $package ) {
+			/**
+			 * Shipping method rate from package.
+			 *
+			 * @var WC_Shipping_Rate $method
+			 */
 			foreach ( $package['rates'] as $method ) {
 				$method_cost = qliro_ensure_numeric( $method->cost );
 
@@ -441,7 +445,7 @@ class Qliro_One_Helper_Cart {
 			$rates = WC_Tax::get_rates( $tax_class );
 			if ( ! empty( $rates ) ) {
 				$first_rate = reset( $rates ); // Only use the first rate returned.
-				// Check if 'rate' key exists; otherwise, fallback to 0
+				// Check if 'rate' key exists; otherwise, fallback to 0.
 				return self::format_vat_rate( $first_rate['rate'] ?? 0 );
 			}
 		}
@@ -458,7 +462,7 @@ class Qliro_One_Helper_Cart {
 	 * @return string
 	 */
 	public static function get_shipping_tax_rate( $shipping_rate ) {
-		$rate = $shipping_rate->get_cost() != 0 ? array_sum( $shipping_rate->get_taxes() ) / $shipping_rate->get_cost() * 100 : 0;
+		$rate = $shipping_rate->get_cost() !== 0 ? array_sum( $shipping_rate->get_taxes() ) / $shipping_rate->get_cost() * 100 : 0;
 
 		return self::format_vat_rate( $rate );
 	}

--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -123,12 +123,19 @@ class Qliro_One_Helper_Order {
 			// we must inverse the price as Qliro expects price <= 0 for discounts.
 			$price = 'Discount' === $order_line['Type'] ? -1 * $price : abs( $price );
 
-			$return_lines[] = array(
+			$return_line = array(
 				'MerchantReference'  => $order_line['MerchantReference'],
 				'Type'               => $order_line['Type'],
 				'Quantity'           => abs( $order_line['Quantity'] ),
 				'PricePerItemIncVat' => wc_format_decimal( $price, min( wc_get_price_decimals(), 2 ) ),
 			);
+
+			$shipping_fee_merchant_reference = $order_line['ShippingFeeMerchantReference'] ?? '';
+			if ( ! empty( $shipping_fee_merchant_reference ) ) {
+				$return_line['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+			}
+
+			$return_lines[] = $return_line;
 		}
 
 		return $return_lines;
@@ -187,7 +194,7 @@ class Qliro_One_Helper_Order {
 	 * @return array
 	 */
 	public static function process_order_item_shipping( $order_item, $order ) {
-		return array(
+		$shipping_line = array(
 			'MerchantReference'  => self::get_reference( $order_item ),
 			'Description'        => $order_item->get_name(),
 			'Quantity'           => 1,
@@ -196,6 +203,14 @@ class Qliro_One_Helper_Order {
 			'PricePerItemExVat'  => self::get_unit_price_ex_vat( $order_item ),
 			'VatRate'            => self::get_tax_rate( $order, $order_item ),
 		);
+
+		$shipping_fee_merchant_reference = self::get_shipping_fee_merchant_reference( $order_item );
+
+		if ( ! empty( $shipping_fee_merchant_reference ) ) {
+			$shipping_line['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+		}
+
+		return $shipping_line;
 	}
 
 	/**
@@ -266,6 +281,29 @@ class Qliro_One_Helper_Order {
 		}
 
 		return $reference;
+	}
+
+	/**
+	 * Gets the shipping fee merchant reference for a shipping order line.
+	 *
+	 * @param WC_Order_Item_Shipping $order_item The WooCommerce shipping order item.
+	 * @return string
+	 */
+	private static function get_shipping_fee_merchant_reference( $order_item ) {
+		if ( 'shipping' !== $order_item->get_type() ) {
+			return '';
+		}
+
+		$method_id       = $order_item->get_method_id();
+		$instance_id     = $order_item->get_instance_id();
+		$method_settings = get_option( "woocommerce_{$method_id}_{$instance_id}_settings", array() );
+
+		$shipping_fee_merchant_reference = $method_settings['qliro_shipping_fee_merchant_reference'] ?? '';
+		$shipping_fee_merchant_reference = '' !== $shipping_fee_merchant_reference
+			? $shipping_fee_merchant_reference
+			: self::get_reference( $order_item );
+
+		return sanitize_text_field( apply_filters( 'qliro_one_shipping_fee_merchant_reference', $shipping_fee_merchant_reference, $order_item, $method_settings ) );
 	}
 
 	/**

--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -144,7 +144,8 @@ class Qliro_One_Helper_Order {
 	/**
 	 * Formats the order lines for a refund request.
 	 *
-	 * @param int $order_id The WooCommerce Order ID.
+	 * @param array $items Items to refund with quantities.
+	 * @param int   $order_id The WooCommerce Order ID.
 	 * @return array
 	 */
 	public static function get_return_items_from_items( $items, $order_id ) {
@@ -377,6 +378,7 @@ class Qliro_One_Helper_Order {
 	 * @param array    $return_fees The array of return fees.
 	 * @param array    $order_items The order items to send to Qliro for refund.
 	 * @param WC_Order $order The WooCommerce order that is refunded.
+	 * @param bool     $calc_return_fee Whether to calculate and append a return fee delta.
 	 *
 	 * @return array
 	 */
@@ -435,13 +437,25 @@ class Qliro_One_Helper_Order {
 				function ( $original_item ) use ( $reference, $order ) {
 					switch ( $original_item->get_type() ) {
 						case 'line_item':
-							/** @var WC_Order_Item_Product $original_item */
+							/**
+							 * Product order item from original order.
+							 *
+							 * @var WC_Order_Item_Product $original_item
+							 */
 							return $original_item->get_product()->get_sku() === $reference || $original_item->get_product_id() === $reference || $original_item->get_variation_id() === $reference;
 						case 'shipping':
-							/** @var WC_Order_Item_Shipping $original_item */
+							/**
+							 * Shipping order item from original order.
+							 *
+							 * @var WC_Order_Item_Shipping $original_item
+							 */
 							return $original_item->get_method_id() === $reference || $original_item->get_meta( 'qliro_shipping_method' ) === $reference || $order->get_meta( '_qliro_one_shipping_reference' ) === $reference;
 						case 'fee':
-							/** @var WC_Order_Item_Fee $original_item */
+							/**
+							 * Fee order item from original order.
+							 *
+							 * @var WC_Order_Item_Fee $original_item
+							 */
 							return qliro_one_format_fee_reference( $original_item->get_name() ) === $reference;
 						default:
 							return false;

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -42,14 +42,18 @@ class Qliro_One_Helper_Shipping_Methods {
 				$method_name     = $method->label;
 				$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
 
-				$shipping_fee_merchant_reference = isset( $method_settings['qliro_shipping_fee_merchant_reference'] ) ? sanitize_text_field( $method_settings['qliro_shipping_fee_merchant_reference'] ) : '';
+				$shipping_fee_merchant_reference = $method_settings['qliro_shipping_fee_merchant_reference'] ?? '';
+				$shipping_fee_merchant_reference = '' !== $shipping_fee_merchant_reference
+					? $shipping_fee_merchant_reference
+					: $method_id;
+
 				$shipping_fee_merchant_reference = apply_filters( 'qliro_one_shipping_fee_merchant_reference', $shipping_fee_merchant_reference, $method, $method_settings );
 
 				$method_price_inc_tax = round( $method_cost + array_sum( $method->taxes ), 2 );
 				$method_price_ex_tax  = round( $method_cost, 2 );
 				$options              = array(
 					'MerchantReference'            => $method_id,
-					'ShippingFeeMerchantReference' => ! empty( $shipping_fee_merchant_reference ) ? $shipping_fee_merchant_reference : $method_id,
+					'ShippingFeeMerchantReference' => sanitize_text_field( $shipping_fee_merchant_reference ),
 					'DisplayName'                  => $method_name,
 					'PriceIncVat'                  => $method_price_inc_tax,
 					'PriceExVat'                   => $method_price_ex_tax,

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -109,7 +109,7 @@ class Qliro_One_Helper_Shipping_Methods {
 				}
 
 				// Pickup points.
-				self::set_pickup_points( $options, $method );
+				self::set_pickup_points( $options, $method, $shipping_fee_merchant_reference );
 				$shipping_options[] = apply_filters( 'qliro_one_shipping_option', $options, $method, $method_settings );
 
 			}
@@ -122,8 +122,9 @@ class Qliro_One_Helper_Shipping_Methods {
 	 *
 	 * @param array            $options The shipping options for the Qliro api.
 	 * @param WC_Shipping_Rate $method The shipping method rate from WooCommerce.
+	 * @param string           $shipping_fee_merchant_reference The shipping fee merchant reference.
 	 */
-	private static function set_pickup_points( &$options, $method ) {
+	private static function set_pickup_points( &$options, $method, $shipping_fee_merchant_reference = '' ) {
 		// Get any pickup points for the shipping method.
 		$pickup_points = QLIRO_WC()->pickup_points_service()->get_pickup_points_from_rate( $method ) ?? array();
 
@@ -150,6 +151,10 @@ class Qliro_One_Helper_Shipping_Methods {
 					'DateStart' => $pickup_point->get_eta()->get_utc(),
 				),
 			);
+
+			if ( ! empty( $shipping_fee_merchant_reference ) ) {
+				$secondary_option['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+			}
 
 			// Only add coordinates if available.
 			if ( ! empty( $latitude ) || ! empty( $longitude ) ) {

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -47,18 +47,21 @@ class Qliro_One_Helper_Shipping_Methods {
 					? $shipping_fee_merchant_reference
 					: $method_id;
 
-				$shipping_fee_merchant_reference = apply_filters( 'qliro_one_shipping_fee_merchant_reference', $shipping_fee_merchant_reference, $method, $method_settings );
+				$shipping_fee_merchant_reference = sanitize_text_field( apply_filters( 'qliro_one_shipping_fee_merchant_reference', $shipping_fee_merchant_reference, $method, $method_settings ) );
 
 				$method_price_inc_tax = round( $method_cost + array_sum( $method->taxes ), 2 );
 				$method_price_ex_tax  = round( $method_cost, 2 );
 				$options              = array(
-					'MerchantReference'            => $method_id,
-					'ShippingFeeMerchantReference' => sanitize_text_field( $shipping_fee_merchant_reference ),
-					'DisplayName'                  => $method_name,
-					'PriceIncVat'                  => $method_price_inc_tax,
-					'PriceExVat'                   => $method_price_ex_tax,
-					'VatRate'                      => Qliro_One_Helper_Cart::get_shipping_tax_rate( $method ),
+					'MerchantReference' => $method_id,
+					'DisplayName'       => $method_name,
+					'PriceIncVat'       => $method_price_inc_tax,
+					'PriceExVat'        => $method_price_ex_tax,
+					'VatRate'           => Qliro_One_Helper_Cart::get_shipping_tax_rate( $method ),
 				);
+
+				if ( ! empty( $shipping_fee_merchant_reference ) ) {
+					$options['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+				}
 
 				// Set the shipping method description if it exists.
 				self::set_shipping_method_description( $method, $method_settings, $options );

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -26,7 +26,11 @@ class Qliro_One_Helper_Shipping_Methods {
 		$shipping_options = array();
 		$packages         = WC()->shipping->get_packages();
 		foreach ( $packages as $i => $package ) {
-			/** @var WC_Shipping_Rate $method */
+			/**
+			 * Shipping method rate object.
+			 *
+			 * @var WC_Shipping_Rate $method
+			 */
 			foreach ( $package['rates'] as $method ) {
 				$method_cost = qliro_ensure_numeric( $method->cost );
 				// If the method id contains the qliro_shipping string, skip.

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -34,20 +34,23 @@ class Qliro_One_Helper_Shipping_Methods {
 					continue;
 				}
 
-				$method_id   = $method->id;
-				$method_name = $method->label;
+				$method_id       = $method->id;
+				$method_name     = $method->label;
+				$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
+
+				$shipping_fee_merchant_reference = isset( $method_settings['qliro_shipping_fee_merchant_reference'] ) ? sanitize_text_field( $method_settings['qliro_shipping_fee_merchant_reference'] ) : '';
+				$shipping_fee_merchant_reference = apply_filters( 'qliro_one_shipping_fee_merchant_reference', $shipping_fee_merchant_reference, $method, $method_settings );
 
 				$method_price_inc_tax = round( $method_cost + array_sum( $method->taxes ), 2 );
 				$method_price_ex_tax  = round( $method_cost, 2 );
 				$options              = array(
-					'MerchantReference' => $method_id,
-					'DisplayName'       => $method_name,
-					'PriceIncVat'       => $method_price_inc_tax,
-					'PriceExVat'        => $method_price_ex_tax,
-					'VatRate'           => Qliro_One_Helper_Cart::get_shipping_tax_rate( $method ),
+					'MerchantReference'            => $method_id,
+					'ShippingFeeMerchantReference' => ! empty( $shipping_fee_merchant_reference ) ? $shipping_fee_merchant_reference : $method_id,
+					'DisplayName'                  => $method_name,
+					'PriceIncVat'                  => $method_price_inc_tax,
+					'PriceExVat'                   => $method_price_ex_tax,
+					'VatRate'                      => Qliro_One_Helper_Cart::get_shipping_tax_rate( $method ),
 				);
-
-				$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
 
 				// Set the shipping method description if it exists.
 				self::set_shipping_method_description( $method, $method_settings, $options );


### PR DESCRIPTION
Adds a shipping method setting together with the `qliro_one_shipping_fee_merchant_reference` filter, to enable sending a custom `ShippingFeeMerchantReference` value to Qliro. Defaults to the shipping method's id.