### PR TITLE
Fix needs_payment for completed purchases

### DIFF
--- a/.changelogs/2026-03-16-needs-payment-pay-button
+++ b/.changelogs/2026-03-16-needs-payment-pay-button
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Prevent the order from entering an invalid needs payment state when the 'qliro_check_if_needs_payment' filter is active and set to false. This would make a 'Pay' button appear on the order received page even for completed purchases.

--- a/classes/class-qliro-one-checkout.php
+++ b/classes/class-qliro-one-checkout.php
@@ -168,6 +168,11 @@ class Qliro_One_Checkout {
 		WC()->session->set( 'qliro_one_last_update_hash', $hash );
 	}
 
+	/**
+	 * Calculate a hash based on the current cart and checkout data, to be able to compare if anything has changed since last update.
+	 *
+	 * @return string
+	 */
 	public static function calculate_hash() {
 		// Get values to use for the combined hash calculation.
 		$totals = WC()->cart->get_totals();
@@ -208,7 +213,6 @@ class Qliro_One_Checkout {
 		foreach ( $packages as $package ) {
 			// Loop each rate in the package.
 			foreach ( $package['rates'] as $rate ) {
-				/** @var WC_Shipping_Rate $rate */
 				$pickup_point = QLIRO_WC()->pickup_points_service()->get_pickup_point_from_rate_by_id( $rate, $selected_option );
 				if ( ! $pickup_point ) {
 					continue;
@@ -254,7 +258,7 @@ class Qliro_One_Checkout {
 	 * Needed since Qliro checkout has a field for states that is a text input, and WooCommerce renders a select field if a country has states listed.
 	 * This makes it hard or almost impossible to select the correct state in WooCommerce based on the user input in Qliro checkout.
 	 *
-	 * @param array $states The states.
+	 * @param array $country_states The states.
 	 * @return array
 	 */
 	public function maybe_unset_states_from_countries( $country_states ) {

--- a/classes/class-qliro-one-checkout.php
+++ b/classes/class-qliro-one-checkout.php
@@ -133,7 +133,7 @@ class Qliro_One_Checkout {
 		// If cart doesn't need payment anymore - reload the checkout page.
 		if ( apply_filters( 'qliro_check_if_needs_payment', true ) ) {
 			if ( ! WC()->cart->needs_payment() ) {
-				WC()->session->reload_checkout = true;
+				WC()->session->set( 'reload_checkout', true );
 			}
 		}
 
@@ -262,7 +262,6 @@ class Qliro_One_Checkout {
 		if ( empty( WC()->session ) || 'qliro_one' !== WC()->session->get( 'chosen_payment_method' ) ) {
 			return $country_states;
 		}
-
 
 		// Ensure each country (key) has a empty array as a value.
 		foreach ( $country_states as $cc => $states ) {

--- a/classes/class-qliro-one-gateway.php
+++ b/classes/class-qliro-one-gateway.php
@@ -366,6 +366,12 @@ class Qliro_One_Gateway extends WC_Payment_Gateway {
 			return $wc_result;
 		}
 
+		// Do not override the needs payment result if the order is not in a valid status for needing payment.
+		// This is necessary to prevent 'processing' orders from being marked as needing payment. Otherwise, a "Pay" button will appear on the order received page.
+		if ( ! in_array( $order->get_status(), $valid_order_statuses, true ) ) {
+			return $wc_result;
+		}
+
 		// Only if our filter is active and is set to false.
 		if ( apply_filters( 'qliro_check_if_needs_payment', true ) ) {
 			return $wc_result;

--- a/classes/class-qliro-one-gateway.php
+++ b/classes/class-qliro-one-gateway.php
@@ -429,18 +429,23 @@ class Qliro_One_Gateway extends WC_Payment_Gateway {
 		return json_decode( $args, true );
 	}
 
+	/**
+	 * Update conditional settings based on other settings values.
+	 *
+	 * @return void
+	 */
 	public function update_conditional_settings() {
 		$settings = get_option( 'woocommerce_qliro_one_settings', array() );
 
 		// If all locations are set to none, disable the banner widget.
 		$banner_cart_location = sanitize_text_field( $settings['banner_widget_cart_placement_location'] ?? 'woocommerce_cart_collaterals' );
 		$banner_location      = sanitize_text_field( $settings['banner_widget_placement_location'] ?? 'none' );
-		$banner_enabled       = ( $banner_cart_location === 'none' && $banner_location === 'none' ) ? 'no' : 'yes';
+		$banner_enabled       = ( 'none' === $banner_cart_location && 'none' === $banner_location ) ? 'no' : 'yes';
 		update_option( 'woocommerce_qliro_one_banner_widget_enabled', $banner_enabled );
 
 		// If the payment widget location is set to none, disable the payment widget.
 		$payment_location = sanitize_text_field( $settings['payment_widget_placement_location'] ?? '15' );
-		$payment_enabled  = ( $payment_location === 'none' ) ? 'no' : 'yes';
+		$payment_enabled  = ( 'none' === $payment_location ) ? 'no' : 'yes';
 		update_option( 'woocommerce_qliro_one_payment_widget_enabled', $payment_enabled );
 
 		$om_advanced_settings = sanitize_text_field( $settings['om_advanced_settings'] ?? 'no' );


### PR DESCRIPTION
When the `qliro_check_if_needs_payment` filter is active and set to `__return_false`, it will break the needs payment state for completed purchases. This would result in the completed purchase having a "Pay" button on the order received page.

https://app.clickup.com/t/869c9nthk