### PR TITLE
Shipping fee merchant reference

### DIFF
--- a/.changelogs/2026-04-03-shipping-fee-merchant-ref
+++ b/.changelogs/2026-04-03-shipping-fee-merchant-ref
@@ -1,0 +1,4 @@
+Type: Feature
+Needs Documentation: yes
+
+Added a shipping method setting together with the 'qliro_one_shipping_fee_merchant_reference' filter, to enable sending a custom ShippingFeeMerchantReference value to Qliro. Defaults to the shipping method's id.

--- a/classes/class-qliro-one-shipping-method-instance.php
+++ b/classes/class-qliro-one-shipping-method-instance.php
@@ -41,13 +41,13 @@ class Qliro_One_Shipping_Method_Instance {
 	 */
 	public function add_shipping_method_fields( $shipping_method_fields ) {
 		$settings_fields = array(
-			'qliro_shipping_settings'     => array(
+			'qliro_shipping_settings'               => array(
 				'title'       => __( 'Qliro shipping settings', 'qliro-for-woocommerce' ),
 				'type'        => 'title',
 				'description' => __( 'These settings let you customize the shipping methods in Qliro checkout, and only apply when you show the shipping options in the iframe. ', 'qliro-for-woocommerce' ),
 				'default'     => '',
 			),
-			'qliro_description'           => array(
+			'qliro_description'                     => array(
 				'title'       => __( 'Description', 'qliro-for-woocommerce' ),
 				'type'        => 'textarea',
 				'default'     => '',
@@ -55,7 +55,14 @@ class Qliro_One_Shipping_Method_Instance {
 				'placeholder' => __( 'Maximum length is 100 characters per line and up to 3 lines.', 'qliro-for-woocommerce' ),
 				'desc_tip'    => true,
 			),
-			'qliro_delivery_date_start'   => array(
+			'qliro_shipping_fee_merchant_reference' => array(
+				'title'       => __( 'Shipping fee merchant reference', 'qliro-for-woocommerce' ),
+				'type'        => 'text',
+				'default'     => '',
+				'description' => __( 'Custom value sent as ShippingFeeMerchantReference for this shipping method.', 'qliro-for-woocommerce' ),
+				'desc_tip'    => true,
+			),
+			'qliro_delivery_date_start'             => array(
 				'title'   => __( 'Delivery start date', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -73,7 +80,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'10'   => __( 'In 10 days', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_delivery_date_end'     => array(
+			'qliro_delivery_date_end'               => array(
 				'title'   => __( 'Delivery end date', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -91,7 +98,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'10'   => __( 'In 10 days', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_category_display_name' => array(
+			'qliro_category_display_name'           => array(
 				'title'   => __( 'Category Display Name', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -101,7 +108,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'PICKUP'        => __( 'Pickup Point', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_label_display_name'    => array(
+			'qliro_label_display_name'              => array(
 				'title'   => __( 'Label Display Name', 'qliro-for-woocommerce' ),
 				'type'    => 'select',
 				'default' => 'none',
@@ -112,7 +119,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'free'    => __( 'Free', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_brand'                 => array(
+			'qliro_brand'                           => array(
 				'title'       => __( 'Brand', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -142,7 +149,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'Ups'         => 'UPS',
 				),
 			),
-			'qliro_option_label_eco'      => array(
+			'qliro_option_label_eco'                => array(
 				'title'       => __( 'ECO friendly label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -155,7 +162,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_express'  => array(
+			'qliro_option_label_express'            => array(
 				'title'       => __( 'Express shipping label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -168,7 +175,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_evening'  => array(
+			'qliro_option_label_evening'            => array(
 				'title'       => __( 'Evening delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -181,7 +188,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_morning'  => array(
+			'qliro_option_label_morning'            => array(
 				'title'       => __( 'Morning delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -194,7 +201,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_home'     => array(
+			'qliro_option_label_home'               => array(
 				'title'       => __( 'Home delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -206,7 +213,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_box'      => array(
+			'qliro_option_label_box'                => array(
 				'title'       => __( 'Box delivery label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -218,7 +225,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'qliro_option_label_pickup'   => array(
+			'qliro_option_label_pickup'             => array(
 				'title'       => __( 'Pickup label', 'qliro-for-woocommerce' ),
 				'type'        => 'select',
 				'default'     => 'none',
@@ -230,7 +237,7 @@ class Qliro_One_Shipping_Method_Instance {
 					'textIcon' => __( 'Text and icon', 'qliro-for-woocommerce' ),
 				),
 			),
-			'tax_status'                  => array(
+			'tax_status'                            => array(
 				'title'   => __( 'Tax status', 'woocommerce' ), // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 				'type'    => 'select',
 				'class'   => 'wc-enhanced-select',

--- a/classes/class-qliro-order-utility.php
+++ b/classes/class-qliro-order-utility.php
@@ -468,16 +468,31 @@ class Qliro_Order_Utility {
 	/**
 	 * Get shipping fee merchant reference for the shipping rate.
 	 *
-	 * @param WC_Shipping_Rate $method The shipping method rate from WooCommerce.
+	 * @param WC_Shipping_Rate|WC_Order_Item_Shipping $method The shipping method object from WooCommerce.
 	 * @return string
 	 */
 	public static function get_shipping_fee_merchant_reference_from_rate( $method ) {
-		$method_id       = $method->get_id();
-		$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
+		$method_id   = '';
+		$rate_id     = '';
+		$instance_id = 0;
+
+		if ( $method instanceof WC_Order_Item_Shipping ) {
+			$method_id   = $method->get_method_id();
+			$instance_id = $method->get_instance_id();
+			$rate_id     = $method_id . ':' . $instance_id;
+		} else {
+			$method_id   = method_exists( $method, 'get_method_id' ) ? $method->get_method_id() : ( $method->method_id ?? '' );
+			$instance_id = method_exists( $method, 'get_instance_id' ) ? $method->get_instance_id() : ( $method->instance_id ?? 0 );
+			$rate_id     = method_exists( $method, 'get_id' ) ? $method->get_id() : $method_id . ':' . $instance_id;
+		}
+
+		$rate_id = ! empty( $rate_id ) ? $rate_id : $method_id . ':' . $instance_id;
+
+		$method_settings = get_option( "woocommerce_{$method_id}_{$instance_id}_settings", array() );
 
 		$shipping_fee_merchant_reference = ! empty( $method_settings['qliro_shipping_fee_merchant_reference'] )
 			? $method_settings['qliro_shipping_fee_merchant_reference']
-			: $method_id;
+			: $rate_id;
 
 		$shipping_fee_merchant_reference = sanitize_text_field(
 			apply_filters(
@@ -488,6 +503,6 @@ class Qliro_Order_Utility {
 			)
 		);
 
-		return ! empty( $shipping_fee_merchant_reference ) ? $shipping_fee_merchant_reference : $method_id;
+		return ! empty( $shipping_fee_merchant_reference ) ? $shipping_fee_merchant_reference : $rate_id;
 	}
 }

--- a/classes/class-qliro-order-utility.php
+++ b/classes/class-qliro-order-utility.php
@@ -464,4 +464,30 @@ class Qliro_Order_Utility {
 			}
 		}
 	}
+
+	/**
+	 * Get shipping fee merchant reference for the shipping rate.
+	 *
+	 * @param WC_Shipping_Rate $method The shipping method rate from WooCommerce.
+	 * @return string
+	 */
+	public static function get_shipping_fee_merchant_reference_from_rate( $method ) {
+		$method_id       = $method->get_id();
+		$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
+
+		$shipping_fee_merchant_reference = ! empty( $method_settings['qliro_shipping_fee_merchant_reference'] )
+			? $method_settings['qliro_shipping_fee_merchant_reference']
+			: $method_id;
+
+		$shipping_fee_merchant_reference = sanitize_text_field(
+			apply_filters(
+				'qliro_one_shipping_fee_merchant_reference',
+				$shipping_fee_merchant_reference,
+				$method,
+				$method_settings
+			)
+		);
+
+		return ! empty( $shipping_fee_merchant_reference ) ? $shipping_fee_merchant_reference : $method_id;
+	}
 }

--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -25,7 +25,7 @@ class Qliro_One_Helper_Cart {
 	 *
 	 * @param object $cart The WooCommerce cart object.
 	 * @param bool   $new_order Whether the cart items are for a new order.
-
+	 *
 	 * @return array Formatted cart items.
 	 */
 	public static function get_cart_items( $cart = null, $new_order = false ) {

--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -194,7 +194,11 @@ class Qliro_One_Helper_Cart {
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 		$chosen_shipping = $chosen_methods[0];
 		foreach ( $packages as $i => $package ) {
-			/** @var WC_Shipping_Rate $method */
+			/**
+			 * Shipping method rate.
+			 *
+			 * @var WC_Shipping_Rate $method
+			 */
 			foreach ( $package['rates'] as $method ) {
 				$method_cost = qliro_ensure_numeric( $method->cost );
 
@@ -414,7 +418,7 @@ class Qliro_One_Helper_Cart {
 			$rates = WC_Tax::get_rates( $tax_class );
 			if ( ! empty( $rates ) ) {
 				$first_rate = reset( $rates ); // Only use the first rate returned.
-				// Check if 'rate' key exists; otherwise, fallback to 0
+				// Check if 'rate' key exists; otherwise, fallback to 0.
 				return self::format_vat_rate( $first_rate['rate'] ?? 0 );
 			}
 		}
@@ -431,7 +435,7 @@ class Qliro_One_Helper_Cart {
 	 * @return string
 	 */
 	public static function get_shipping_tax_rate( $shipping_rate ) {
-		$rate = $shipping_rate->get_cost() != 0 ? array_sum( $shipping_rate->get_taxes() ) / $shipping_rate->get_cost() * 100 : 0;
+		$rate = $shipping_rate->get_cost() != 0 ? array_sum( $shipping_rate->get_taxes() ) / $shipping_rate->get_cost() * 100 : 0; // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
 
 		return self::format_vat_rate( $rate );
 	}

--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -24,9 +24,11 @@ class Qliro_One_Helper_Cart {
 	 * Gets formatted cart items.
 	 *
 	 * @param object $cart The WooCommerce cart object.
+	 * @param bool   $new_order Whether the cart items are for a new order.
+
 	 * @return array Formatted cart items.
 	 */
-	public static function get_cart_items( $cart = null ) {
+	public static function get_cart_items( $cart = null, $new_order = false ) {
 		$formatted_cart_items = array();
 
 		if ( null === $cart ) {
@@ -50,7 +52,7 @@ class Qliro_One_Helper_Cart {
 
 		// Get cart shipping.
 		if ( WC()->cart->needs_shipping() && ! QLIRO_WC()->checkout()->is_shipping_in_iframe_enabled() ) {
-			$shipping = self::get_shipping();
+			$shipping = self::get_shipping( $new_order );
 			if ( null !== $shipping ) {
 				$formatted_cart_items[] = $shipping;
 			}
@@ -184,9 +186,10 @@ class Qliro_One_Helper_Cart {
 	/**
 	 * Formats the shipping.
 	 *
+	 * @param bool $new_order Whether the shipping is for a new order.
 	 * @return array|null
 	 */
-	public static function get_shipping() {
+	public static function get_shipping( $new_order = false ) {
 		$packages        = WC()->shipping()->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
 		$chosen_shipping = $chosen_methods[0];
@@ -196,9 +199,11 @@ class Qliro_One_Helper_Cart {
 				$method_cost = qliro_ensure_numeric( $method->cost );
 
 				if ( $chosen_shipping === $method->id ) {
+					$shipping_fee_merchant_reference = Qliro_Order_Utility::get_shipping_fee_merchant_reference_from_rate( $method );
+
 					if ( $method_cost > 0 ) {
 						return array(
-							'MerchantReference'  => $method->get_id(),
+							'MerchantReference'  => ! $new_order ? $shipping_fee_merchant_reference : $method->get_id(),
 							'Description'        => $method->get_label(),
 							'Type'               => 'Shipping',
 							'Quantity'           => 1,
@@ -209,7 +214,7 @@ class Qliro_One_Helper_Cart {
 					}
 
 					return array(
-						'MerchantReference'  => $method->get_id(),
+						'MerchantReference'  => ! $new_order ? $shipping_fee_merchant_reference : $method->get_id(),
 						'Description'        => $method->get_label(),
 						'Type'               => 'Shipping',
 						'Quantity'           => 1,

--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -138,7 +138,8 @@ class Qliro_One_Helper_Order {
 	/**
 	 * Formats the order lines for a refund request.
 	 *
-	 * @param int $order_id The WooCommerce Order ID.
+	 * @param array $items The items to be refunded.
+	 * @param int   $order_id The WooCommerce Order ID.
 	 * @return array
 	 */
 	public static function get_return_items_from_items( $items, $order_id ) {
@@ -185,6 +186,7 @@ class Qliro_One_Helper_Order {
 	 *
 	 * @param WC_Order_Item_Shipping $order_item The WooCommerce order line item.
 	 * @param WC_Order|null          $order The WooCommerce order.
+	 * @param bool                   $new_order Whether the order lines are being retrieved for a new order or an existing order.
 	 * @return array
 	 */
 	public static function process_order_item_shipping( $order_item, $order, $new_order = false ) {
@@ -400,13 +402,25 @@ class Qliro_One_Helper_Order {
 				function ( $original_item ) use ( $reference, $order ) {
 					switch ( $original_item->get_type() ) {
 						case 'line_item':
-							/** @var WC_Order_Item_Product $original_item */
+							/**
+							 * The original item as a WC_Order_Item_Product.
+							 *
+							 * @var WC_Order_Item_Product $original_item
+							 */
 							return $original_item->get_product()->get_sku() === $reference || $original_item->get_product_id() === $reference || $original_item->get_variation_id() === $reference;
 						case 'shipping':
-							/** @var WC_Order_Item_Shipping $original_item */
+							/**
+							 * The original item as a WC_Order_Item_Shipping.
+							 *
+							 * @var WC_Order_Item_Shipping $original_item
+							 */
 							return $original_item->get_method_id() === $reference || $original_item->get_meta( 'qliro_shipping_method' ) === $reference || $order->get_meta( '_qliro_one_shipping_reference' ) === $reference;
 						case 'fee':
-							/** @var WC_Order_Item_Fee $original_item */
+							/**
+							 * The original item as a WC_Order_Item_Fee.
+							 *
+							 * @var WC_Order_Item_Fee $original_item
+							 */
 							return qliro_one_format_fee_reference( $original_item->get_name() ) === $reference;
 						default:
 							return false;

--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -188,8 +188,7 @@ class Qliro_One_Helper_Order {
 	 * @return array
 	 */
 	public static function process_order_item_shipping( $order_item, $order, $new_order = false ) {
-		$method                          = ''; // Need to fetch this here.
-		$shipping_fee_merchant_reference = Qliro_Order_Utility::get_shipping_fee_merchant_reference_from_rate( $method );
+		$shipping_fee_merchant_reference = Qliro_Order_Utility::get_shipping_fee_merchant_reference_from_rate( $order_item );
 
 		return array(
 			'MerchantReference'  => ! $new_order ? $shipping_fee_merchant_reference : self::get_reference( $order_item ),

--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -344,6 +344,7 @@ class Qliro_One_Helper_Order {
 	 * @param array    $return_fees The array of return fees.
 	 * @param array    $order_items The order items to send to Qliro for refund.
 	 * @param WC_Order $order The WooCommerce order that is refunded.
+	 * @param bool     $calc_return_fee Whether to calculate the return fee.
 	 *
 	 * @return array
 	 */

--- a/classes/requests/helpers/class-qliro-one-helper-order.php
+++ b/classes/requests/helpers/class-qliro-one-helper-order.php
@@ -18,9 +18,10 @@ class Qliro_One_Helper_Order {
 	 *
 	 * @param int   $order_id The WooCommerce order id.
 	 * @param array $items The order items (optional).
+	 * @param bool  $new_order Whether the order lines are being retrieved for a new order or an existing order.
 	 * @return array
 	 */
-	public static function get_order_items( $order_id, $items = array() ) {
+	public static function get_order_items( $order_id, $items = array(), $new_order = false ) {
 		$order       = wc_get_order( $order_id );
 		$order_lines = array();
 
@@ -49,12 +50,12 @@ class Qliro_One_Helper_Order {
 		foreach ( $order->get_items( 'shipping' ) as $order_item ) {
 			if ( ! empty( $items ) ) {
 				if ( isset( $items[ $order_item->get_id() ] ) ) {
-					$order_lines[] = self::process_order_item_shipping( $order_item, $order );
+					$order_lines[] = self::process_order_item_shipping( $order_item, $order, $new_order );
 				} else {
 					continue;
 				}
 			} else {
-				$order_lines[] = self::process_order_item_shipping( $order_item, $order );
+				$order_lines[] = self::process_order_item_shipping( $order_item, $order, $new_order );
 			}
 		}
 
@@ -186,9 +187,12 @@ class Qliro_One_Helper_Order {
 	 * @param WC_Order|null          $order The WooCommerce order.
 	 * @return array
 	 */
-	public static function process_order_item_shipping( $order_item, $order ) {
+	public static function process_order_item_shipping( $order_item, $order, $new_order = false ) {
+		$method                          = ''; // Need to fetch this here.
+		$shipping_fee_merchant_reference = Qliro_Order_Utility::get_shipping_fee_merchant_reference_from_rate( $method );
+
 		return array(
-			'MerchantReference'  => self::get_reference( $order_item ),
+			'MerchantReference'  => ! $new_order ? $shipping_fee_merchant_reference : self::get_reference( $order_item ),
 			'Description'        => $order_item->get_name(),
 			'Quantity'           => 1,
 			'Type'               => 'Shipping',

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -27,7 +27,10 @@ class Qliro_One_Helper_Shipping_Methods {
 		$shipping_options = array();
 		$packages         = WC()->shipping->get_packages();
 		foreach ( $packages as $i => $package ) {
-			/** @var WC_Shipping_Rate $method */
+			/** Shipping method rate.
+			 *
+			 * @var WC_Shipping_Rate $method
+			 */
 			foreach ( $package['rates'] as $method ) {
 				$method_cost = qliro_ensure_numeric( $method->cost );
 				// If the method id contains the qliro_shipping string, skip.

--- a/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
+++ b/classes/requests/helpers/class-qliro-one-helper-shipping-methods.php
@@ -12,9 +12,10 @@ class Qliro_One_Helper_Shipping_Methods {
 	/**
 	 * Get the available shipping methods.
 	 *
+	 * @param bool $new_order Whether the shipping methods are being retrieved for a new order or an existing order.
 	 * @return array
 	 */
-	public static function get_shipping_methods() {
+	public static function get_shipping_methods( $new_order = false ) {
 		if ( ! QLIRO_WC()->checkout()->is_shipping_in_iframe_enabled() ) {
 			return array();
 		}
@@ -34,18 +35,23 @@ class Qliro_One_Helper_Shipping_Methods {
 					continue;
 				}
 
-				$method_id   = $method->id;
-				$method_name = $method->label;
+				$method_id                       = $method->id;
+				$method_name                     = $method->label;
+				$method_price_inc_tax            = round( $method_cost + array_sum( $method->taxes ), 2 );
+				$method_price_ex_tax             = round( $method_cost, 2 );
+				$shipping_fee_merchant_reference = Qliro_Order_Utility::get_shipping_fee_merchant_reference_from_rate( $method );
 
-				$method_price_inc_tax = round( $method_cost + array_sum( $method->taxes ), 2 );
-				$method_price_ex_tax  = round( $method_cost, 2 );
-				$options              = array(
-					'MerchantReference' => $method_id,
+				$options = array(
+					'MerchantReference' => ! $new_order ? $shipping_fee_merchant_reference : $method_id,
 					'DisplayName'       => $method_name,
 					'PriceIncVat'       => $method_price_inc_tax,
 					'PriceExVat'        => $method_price_ex_tax,
 					'VatRate'           => Qliro_One_Helper_Cart::get_shipping_tax_rate( $method ),
 				);
+
+				if ( $new_order && ( $shipping_fee_merchant_reference !== $method_id ) ) {
+					$options['ShippingFeeMerchantReference'] = $shipping_fee_merchant_reference;
+				}
 
 				$method_settings = get_option( "woocommerce_{$method->method_id}_{$method->instance_id}_settings", array() );
 

--- a/classes/requests/post/class-qliro-one-request-create-order.php
+++ b/classes/requests/post/class-qliro-one-request-create-order.php
@@ -196,6 +196,6 @@ class Qliro_One_Request_Create_Order extends Qliro_One_Request_Post {
 			return null;
 		}
 
-		return get_permalink( $wc_privacy_policy_page_id ) ?: null;
+		return get_permalink( $wc_privacy_policy_page_id ) ? get_permalink( $wc_privacy_policy_page_id ) : null;
 	}
 }

--- a/classes/requests/post/class-qliro-one-request-create-order.php
+++ b/classes/requests/post/class-qliro-one-request-create-order.php
@@ -88,9 +88,9 @@ class Qliro_One_Request_Create_Order extends Qliro_One_Request_Post {
 			'AskForNewsletterSignup'               => $this->get_ask_for_newsletter(),
 			'AskForNewsletterSignUpText'           => $this->get_ask_for_newsletter_label(),
 			'AskForNewsletterSignupChecked'        => $this->get_asked_for_newsletter_checked(),
-			'OrderItems'                           => Qliro_One_Helper_Cart::get_cart_items(),
+			'OrderItems'                           => Qliro_One_Helper_Cart::get_cart_items( null, true ),
 			'MerchantApiKey'                       => $this->get_qliro_key(),
-			'AvailableShippingMethods'             => Qliro_One_Helper_Shipping_Methods::get_shipping_methods(),
+			'AvailableShippingMethods'             => Qliro_One_Helper_Shipping_Methods::get_shipping_methods( true ),
 		);
 
 		if ( ! empty( $this->get_enforced_juridicial_type() ) ) {
@@ -163,7 +163,7 @@ class Qliro_One_Request_Create_Order extends Qliro_One_Request_Post {
 			'AskForNewsletterSignup'               => $this->get_ask_for_newsletter(),
 			'AskForNewsletterSignUpText'           => $this->get_ask_for_newsletter_label(),
 			'AskForNewsletterSignupChecked'        => $this->get_asked_for_newsletter_checked(),
-			'OrderItems'                           => Qliro_One_Helper_Order::get_order_items( $this->order_id ),
+			'OrderItems'                           => Qliro_One_Helper_Order::get_order_items( $this->order_id, true ),
 			'MerchantApiKey'                       => $this->get_qliro_key(),
 			'EnforcedJuridicalType'                => $this->get_enforced_juridicial_type(),
 			'PrimaryColor'                         => $this->get_primary_color(),

--- a/classes/requests/post/class-qliro-one-request-create-order.php
+++ b/classes/requests/post/class-qliro-one-request-create-order.php
@@ -163,7 +163,7 @@ class Qliro_One_Request_Create_Order extends Qliro_One_Request_Post {
 			'AskForNewsletterSignup'               => $this->get_ask_for_newsletter(),
 			'AskForNewsletterSignUpText'           => $this->get_ask_for_newsletter_label(),
 			'AskForNewsletterSignupChecked'        => $this->get_asked_for_newsletter_checked(),
-			'OrderItems'                           => Qliro_One_Helper_Order::get_order_items( $this->order_id, true ),
+			'OrderItems'                           => Qliro_One_Helper_Order::get_order_items( $this->order_id, array(), true ),
 			'MerchantApiKey'                       => $this->get_qliro_key(),
 			'EnforcedJuridicalType'                => $this->get_enforced_juridicial_type(),
 			'PrimaryColor'                         => $this->get_primary_color(),


### PR DESCRIPTION
Adds a shipping method setting together with the `qliro_one_shipping_fee_merchant_reference` filter, to enable sending a custom ShippingFeeMerchantReference value to Qliro. Defaults to the shipping method's id.