### PR TITLE
Display scheduled actions in metabox

### DIFF
--- a/.changelogs/2026-04-29-scheduled-actions-in-metabox
+++ b/.changelogs/2026-04-29-scheduled-actions-in-metabox
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: yes
+
+Scheduled actions related to an order are now shown in the order metabox, to make troubleshooting easier.

--- a/classes/class-qliro-one-callbacks.php
+++ b/classes/class-qliro-one-callbacks.php
@@ -11,6 +11,7 @@
 class Qliro_One_Callbacks {
 
 	public const SCHEDULE_INTERVAL_SEC = 30;
+	public const CHECKOUT_CALLBACKS    = 'qliro_checkout_callbacks';
 
 	/**
 	 * The settings for the plugin.
@@ -115,15 +116,15 @@ class Qliro_One_Callbacks {
 			switch ( $data['Status'] ) {
 				case 'Completed':
 					Qliro_One_Logger::log( "Scheduling completed checkout callback for order with confirmation_id {$confirmation_id}." );
-					as_schedule_single_action( $timestamp, 'qliro_complete_checkout', array( $confirmation_id ), 'qliro_checkout_callbacks' );
+					as_schedule_single_action( $timestamp, 'qliro_complete_checkout', array( $confirmation_id ), self::CHECKOUT_CALLBACKS );
 					break;
 				case 'Refused':
 					Qliro_One_Logger::log( "Scheduling refused callback for order with confirmation_id {$confirmation_id}." );
-					as_schedule_single_action( $timestamp, 'qliro_fail_checkout', array( $confirmation_id ), 'qliro_checkout_callbacks' );
+					as_schedule_single_action( $timestamp, 'qliro_fail_checkout', array( $confirmation_id ), self::CHECKOUT_CALLBACKS );
 					break;
 				case 'OnHold':
 					Qliro_One_Logger::log( "Scheduling onhold callback for order with confirmation_id {$confirmation_id}." );
-					as_schedule_single_action( $timestamp, 'qliro_onhold_checkout', array( $confirmation_id ), 'qliro_checkout_callbacks' );
+					as_schedule_single_action( $timestamp, 'qliro_onhold_checkout', array( $confirmation_id ), self::CHECKOUT_CALLBACKS );
 					break;
 				default:
 					Qliro_One_Logger::log( "Unknown Qliro checkout callback status: {$data['Status']}" );

--- a/classes/class-qliro-one-callbacks.php
+++ b/classes/class-qliro-one-callbacks.php
@@ -115,15 +115,15 @@ class Qliro_One_Callbacks {
 			switch ( $data['Status'] ) {
 				case 'Completed':
 					Qliro_One_Logger::log( "Scheduling completed checkout callback for order with confirmation_id {$confirmation_id}." );
-					as_schedule_single_action( $timestamp, 'qliro_complete_checkout', array( $confirmation_id ) );
+					as_schedule_single_action( $timestamp, 'qliro_complete_checkout', array( $confirmation_id ), 'qliro_checkout_callbacks' );
 					break;
 				case 'Refused':
 					Qliro_One_Logger::log( "Scheduling refused callback for order with confirmation_id {$confirmation_id}." );
-					as_schedule_single_action( $timestamp, 'qliro_fail_checkout', array( $confirmation_id ) );
+					as_schedule_single_action( $timestamp, 'qliro_fail_checkout', array( $confirmation_id ), 'qliro_checkout_callbacks' );
 					break;
 				case 'OnHold':
 					Qliro_One_Logger::log( "Scheduling onhold callback for order with confirmation_id {$confirmation_id}." );
-					as_schedule_single_action( $timestamp, 'qliro_onhold_checkout', array( $confirmation_id ) );
+					as_schedule_single_action( $timestamp, 'qliro_onhold_checkout', array( $confirmation_id ), 'qliro_checkout_callbacks' );
 					break;
 				default:
 					Qliro_One_Logger::log( "Unknown Qliro checkout callback status: {$data['Status']}" );

--- a/classes/class-qliro-one-metabox.php
+++ b/classes/class-qliro-one-metabox.php
@@ -96,7 +96,7 @@ class Qliro_One_Metabox extends OrderMetabox {
 
 			self::output_info(
 				__( 'Scheduled actions', 'qliro-for-woocommerce' ),
-				'<a target="_blank" href="' . $link_url . '">' . $link_text . '</a>'
+				'<a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . esc_html( $link_text ) . '</a>'
 			);
 
 		}

--- a/classes/class-qliro-one-metabox.php
+++ b/classes/class-qliro-one-metabox.php
@@ -87,6 +87,20 @@ class Qliro_One_Metabox extends OrderMetabox {
 		if ( $order_sync_disabled ) {
 			self::output_info( __( 'Order management', 'qliro-for-woocommerce' ), __( 'Disabled', 'qliro-for-woocommerce' ) );
 		}
+
+		$confirmation_id = $order->get_meta( '_qliro_one_order_confirmation_id' );
+		if ( ! empty( $confirmation_id ) ) {
+			$scheduled_actions = Qliro_Scheduled_Actions::get_scheduled_actions( $confirmation_id, gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ) );
+			$link_text         = count( $scheduled_actions['complete'] ) . ' completed, ' . count( $scheduled_actions['failed'] ) . ' failed, ' . count( $scheduled_actions['pending'] ) . ' pending';
+			$link_url          = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
+
+			self::output_info(
+				__( 'Scheduled actions', 'qliro-for-woocommerce' ),
+				'<a target="_blank" href="' . $link_url . '">' . $link_text . '</a>'
+			);
+
+		}
+
 		echo '<br />';
 
 		self::output_sync_order_button( $order, $qliro_order, $last_transaction, $order_sync_disabled, $qliro_total );

--- a/classes/class-qliro-one-metabox.php
+++ b/classes/class-qliro-one-metabox.php
@@ -91,12 +91,21 @@ class Qliro_One_Metabox extends OrderMetabox {
 		$confirmation_id = $order->get_meta( '_qliro_one_order_confirmation_id' );
 		if ( ! empty( $confirmation_id ) ) {
 			$scheduled_actions = Qliro_Scheduled_Actions::get_scheduled_actions( $confirmation_id, gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ) );
-			$link_text         = count( $scheduled_actions['complete'] ) . ' completed, ' . count( $scheduled_actions['failed'] ) . ' failed, ' . count( $scheduled_actions['pending'] ) . ' pending';
-			$link_url          = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
+			$completed_count   = count( $scheduled_actions['complete'] );
+			$failed_count      = count( $scheduled_actions['failed'] );
+			$pending_count     = count( $scheduled_actions['pending'] );
+			/* translators: 1: completed actions count, 2: failed actions count, 3: pending actions count. */
+			$link_text = sprintf(
+				__( '%1$s completed, %2$s failed, %3$s pending in the last three months.', 'qliro-for-woocommerce' ),
+				number_format_i18n( $completed_count ),
+				number_format_i18n( $failed_count ),
+				number_format_i18n( $pending_count )
+			);
+			$link_url  = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
 
 			self::output_info(
 				__( 'Scheduled actions', 'qliro-for-woocommerce' ),
-				'<a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . esc_html( $link_text ) . '</a>'
+				esc_html( $link_text ) . '<br><a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . __( 'View all scheduled actions', 'qliro-for-woocommerce' ) . '</a><br>'
 			);
 
 		}

--- a/classes/class-qliro-one-metabox.php
+++ b/classes/class-qliro-one-metabox.php
@@ -90,24 +90,23 @@ class Qliro_One_Metabox extends OrderMetabox {
 
 		$confirmation_id = $order->get_meta( '_qliro_one_order_confirmation_id' );
 		if ( ! empty( $confirmation_id ) ) {
-			$scheduled_actions = Qliro_Scheduled_Actions::get_scheduled_actions( $confirmation_id, gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ) );
+			$scheduled_actions = Qliro_Scheduled_Actions::get_scheduled_actions( $confirmation_id );
 			$completed_count   = count( $scheduled_actions['complete'] );
 			$failed_count      = count( $scheduled_actions['failed'] );
 			$pending_count     = count( $scheduled_actions['pending'] );
-			/* translators: 1: completed actions count, 2: failed actions count, 3: pending actions count. */
-			$link_text = sprintf(
-				__( '%1$s completed, %2$s failed, %3$s pending in the last three months.', 'qliro-for-woocommerce' ),
+			$link_text         = sprintf(
+				/* translators: 1: completed actions count, 2: failed actions count, 3: pending actions count. */
+				__( '%1$s completed, %2$s failed, %3$s pending', 'qliro-for-woocommerce' ),
 				number_format_i18n( $completed_count ),
 				number_format_i18n( $failed_count ),
 				number_format_i18n( $pending_count )
 			);
-			$link_url  = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
+			$link_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
 
 			self::output_info(
 				__( 'Scheduled actions', 'qliro-for-woocommerce' ),
-				esc_html( $link_text ) . '<br><a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . __( 'View all scheduled actions', 'qliro-for-woocommerce' ) . '</a><br>'
+				'<a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . esc_html( $link_text ) . '</a>'
 			);
-
 		}
 
 		echo '<br />';

--- a/classes/class-qliro-scheduled-actions.php
+++ b/classes/class-qliro-scheduled-actions.php
@@ -37,7 +37,7 @@ class Qliro_Scheduled_Actions {
 						'search'       => $confirmation_id,
 						'status'       => array( $status ),
 						'per_page'     => -1,
-						'group'        => 'qliro_checkout_callbacks',
+						'group'        => Qliro_One_Callbacks::CHECKOUT_CALLBACKS,
 						'date'         => $order_created_date,
 						'date_compare' => '>=',
 					),

--- a/classes/class-qliro-scheduled-actions.php
+++ b/classes/class-qliro-scheduled-actions.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class for getting the scheduled actions for an order.
+ *
+ * @package Qliro_One_For_WooCommerce/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Qliro_Scheduled_Actions
+ */
+class Qliro_Scheduled_Actions {
+
+	/**
+	 * Gets the scheduled actions for the order.
+	 *
+	 * @param string $confirmation_id The confirmation ID.
+	 * @param string $order_created_date The order creation date.
+	 * @return array
+	 */
+	public static function get_scheduled_actions( $confirmation_id, $order_created_date ) {
+		$statuses          = array( 'complete', 'failed', 'pending' );
+		$scheduled_actions = array(
+			'complete' => array(),
+			'failed'   => array(),
+			'pending'  => array(),
+		);
+
+		$order_created_timestamp = strtotime( $order_created_date );
+		$three_months_ago        = strtotime( '-3 months' );
+
+		if ( $order_created_timestamp >= $three_months_ago ) {
+			foreach ( $statuses as $status ) {
+				$scheduled_actions[ $status ] = as_get_scheduled_actions(
+					array(
+						'search'       => $confirmation_id,
+						'status'       => array( $status ),
+						'per_page'     => -1,
+						'group'        => 'qliro_checkout_callbacks',
+						'date'         => $order_created_date,
+						'date_compare' => '>=',
+					),
+					'ids'
+				);
+			}
+		}
+
+		return $scheduled_actions;
+	}
+}

--- a/classes/class-qliro-scheduled-actions.php
+++ b/classes/class-qliro-scheduled-actions.php
@@ -16,10 +16,9 @@ class Qliro_Scheduled_Actions {
 	 * Gets the scheduled actions for the order.
 	 *
 	 * @param string $confirmation_id The confirmation ID.
-	 * @param string $order_created_date The order creation date.
 	 * @return array
 	 */
-	public static function get_scheduled_actions( $confirmation_id, $order_created_date ) {
+	public static function get_scheduled_actions( $confirmation_id ) {
 		$statuses          = array( 'complete', 'failed', 'pending' );
 		$scheduled_actions = array(
 			'complete' => array(),
@@ -27,23 +26,17 @@ class Qliro_Scheduled_Actions {
 			'pending'  => array(),
 		);
 
-		$order_created_timestamp = strtotime( $order_created_date );
-		$three_months_ago        = strtotime( '-3 months' );
-
-		if ( $order_created_timestamp >= $three_months_ago ) {
-			foreach ( $statuses as $status ) {
-				$scheduled_actions[ $status ] = as_get_scheduled_actions(
-					array(
-						'search'       => $confirmation_id,
-						'status'       => array( $status ),
-						'per_page'     => -1,
-						'group'        => Qliro_One_Callbacks::CHECKOUT_CALLBACKS,
-						'date'         => $order_created_date,
-						'date_compare' => '>=',
-					),
-					'ids'
-				);
-			}
+		foreach ( $statuses as $status ) {
+			$scheduled_actions[ $status ] = as_get_scheduled_actions(
+				array(
+					// Exact args match is indexed in Action Scheduler, unlike the LIKE-based 'search' parameter.
+					'args'     => array( $confirmation_id ),
+					'status'   => array( $status ),
+					'per_page' => -1,
+					'group'    => Qliro_One_Callbacks::CHECKOUT_CALLBACKS,
+				),
+				'ids'
+			);
 		}
 
 		return $scheduled_actions;

--- a/qliro-for-woocommerce.php
+++ b/qliro-for-woocommerce.php
@@ -268,6 +268,7 @@ if ( ! class_exists( 'Qliro_One_For_WooCommerce' ) ) {
 			include_once QLIRO_WC_PLUGIN_PATH . '/classes/class-qliro-one-product-tab.php';
 			include_once QLIRO_WC_PLUGIN_PATH . '/classes/class-qliro-one-shipping-method-instance.php';
 			include_once QLIRO_WC_PLUGIN_PATH . '/classes/class-qliro-one-metabox.php';
+			include_once QLIRO_WC_PLUGIN_PATH . '/classes/class-qliro-scheduled-actions.php';
 			include_once QLIRO_WC_PLUGIN_PATH . '/classes/class-qliro-one-shipping-method.php';
 			include_once QLIRO_WC_PLUGIN_PATH . '/classes/class-qliro-one-subscriptions.php';
 


### PR DESCRIPTION
Displays scheduled actions related to an order in the order metabox, to make troubleshooting easier.