### PR TITLE
Check if cart is empty before create order

### DIFF
--- a/.changelogs/2026-05-13-prevent-order-creation-on-empty-cart
+++ b/.changelogs/2026-05-13-prevent-order-creation-on-empty-cart
@@ -1,0 +1,4 @@
+Type: Tweak
+Needs Documentation: no
+
+Fixed an edge case where an empty cart could trigger an unnecessary Qliro order creation on the checkout page, as a safeguard for when WooCommerce's built-in redirect does not occur.

--- a/includes/qliro-one-functions.php
+++ b/includes/qliro-one-functions.php
@@ -19,6 +19,11 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 function qliro_one_maybe_create_order() {
 	$cart    = WC()->cart;
 	$session = WC()->session;
+
+	if ( $cart->is_empty() ) {
+		return null;
+	}
+
 	// try to get id from session.
 	$qliro_one_order_id = $session->get( 'qliro_one_order_id' );
 	$cart->calculate_fees();


### PR DESCRIPTION
Typically, WC will redirect the customer away from checkout page if the cart is empty. Somehow, a merchant has managed to initialize the checkout page with an empty cart just long enough to call the maybe_create_order function. This results in unnecessary API  requests to Qliro. We have not been able to recreate the issue, but adding the `cart->is_empty` guard won't hurt.

https://app.clickup.com/t/869d5wgb3