### PR TITLE
Fix blank confirmation page after a completed purchase

### DIFF
--- a/.changelogs/2026-07-31-fix-blank-confirmation-page
+++ b/.changelogs/2026-07-31-fix-blank-confirmation-page
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed the confirmation page rendering blank after a completed purchase on setups whose HTTP layer is strict about header formatting. The redirect to the thank-you page was written as a raw header without the optional space after the colon ("Location:https://..."), which is legal HTTP and passes through Apache and nginx untouched, but is dropped by stricter layers — leaving the customer with a 302 that has no destination. It now uses wp_safe_redirect(), as every other redirect in the plugin already does. The payment itself was never affected: the order was created and confirmed, and only the final redirect was lost.

--- a/.changelogs/2026-07-31-fix-blank-confirmation-page
+++ b/.changelogs/2026-07-31-fix-blank-confirmation-page
@@ -1,4 +1,4 @@
 Type: Fix
 Needs Documentation: no
 
-Fixed the confirmation page rendering blank after a completed purchase on setups whose HTTP layer is strict about header formatting. The redirect to the thank-you page was written as a raw header without the optional space after the colon ("Location:https://..."), which is legal HTTP and passes through Apache and nginx untouched, but is dropped by stricter layers — leaving the customer with a 302 that has no destination. It now uses wp_safe_redirect(), as every other redirect in the plugin already does. The payment itself was never affected: the order was created and confirmed, and only the final redirect was lost.
+Fixed the confirmation page showing up blank after a completed purchase on some server setups.

--- a/classes/class-qliro-one-confirmation.php
+++ b/classes/class-qliro-one-confirmation.php
@@ -43,7 +43,7 @@ class Qliro_One_Confirmation {
 			Qliro_One_Logger::log( "Order ID $order_id confirmed on the confirmation page. Qliro Order ID: $qliro_order_id." );
 		}
 
-		header( 'Location:' . $order->get_checkout_order_received_url() );
+		wp_safe_redirect( $order->get_checkout_order_received_url() );
 		exit;
 	}
 


### PR DESCRIPTION
Based on #232 so it can be tested in the Playground environment that PR introduces. GitHub will retarget this to `develop` when #232 merges.

## Symptom

Completing a purchase in the Qliro iframe sends the customer to `/checkout/?qliro_one_confirm_page=<uuid>`, which renders blank. Measured straight from the origin, so no proxy is involved:

```
HTTP/1.1 302 Found
content-type: text/html; charset=UTF-8
Content-Length: 0
        ← no location header
```

A 302 with no destination — the browser has nowhere to go, so it paints nothing.

## Cause

`classes/class-qliro-one-confirmation.php:46` wrote the redirect as a raw header, omitting the optional space after the colon:

```php
header( 'Location:' . $order->get_checkout_order_received_url() );
```

That is legal HTTP — [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-5.1) makes the whitespace optional — so Apache and nginx pass it through and this has always worked in production. Stricter HTTP layers drop it. PHP sets the 302 either way, because it recognises the header name regardless of spacing, which is what produces a redirect to nowhere rather than a plain error.

Reproduced under WordPress Playground with a two-line probe in the same runtime and PHP version:

| Written as | Response |
|---|---|
| `header('Location: https://…')` | 302 **with** `location:` |
| `header('Location:https://…')` | 302, header dropped |

This was also the only raw `header()` redirect in the plugin — the other six call sites already use `wp_safe_redirect()`, and all of them work on the same site.

## Fix

```php
wp_safe_redirect( $order->get_checkout_order_received_url() );
exit;
```

Consistent with the rest of the plugin, and it brings the standard `wp_redirect` filters plus `X-Redirect-By`. The target is the site's own order-received URL, so `wp_safe_redirect`'s host allowlist passes it.

## Verified

Same URL, same site, after the change:

```
HTTP/1.1 302 Found
x-redirect-by: WordPress
location: https://…/checkout/order-received/40/?key=wc_order_nHsgaLeqMfnzH
```

Following it lands on the thank-you page with HTTP 200 in one hop.

## Scope

The payment was never affected. The order is created and confirmed before this line, and Qliro's status push completes it even when the redirect is lost — which is why the affected orders still reached `processing`. Only the final hop to the thank-you page broke, and with it the customer's confirmation experience.