### PR TITLE
Sign the OM push URL from the checkout, and skip non-preauth callbacks

### DIFF
--- a/.changelogs/2026-07-31-fix-om-callback-token
+++ b/.changelogs/2026-07-31-fix-om-callback-token
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed order management push callbacks being rejected for ordinary orders. The preauthorization callback authenticates on a signed token in the callback URL, but only the subscription renewal request registered a signed URL with Qliro — orders created through the checkout registered an unsigned one. Qliro sends a preauthorization callback for ordinary orders too, so every purchase logged an authentication error and answered Qliro with HTTP 401, telling it the push had failed and prompting retries. The order management push URL is now signed wherever it is built, and callbacks for orders that are not awaiting preauthorization are acknowledged and skipped instead of rejected, which also settles orders whose callback URL was registered before this change. Subscription preauthorization itself is unchanged: it still requires a valid token before the order is touched.

--- a/classes/class-qliro-one-callbacks.php
+++ b/classes/class-qliro-one-callbacks.php
@@ -241,10 +241,30 @@ class Qliro_One_Callbacks {
 	public function complete_preauthorization( $data, $confirmation_id ) {
 		$order_number = $data['MerchantReference'] ?? '';
 
-		// Authenticate the callback using the per-order token in the URL, honouring a grace period for legacy renewal orders.
 		$token = filter_input( INPUT_GET, Qliro_One_Callback_Auth::TOKEN_PARAM, FILTER_SANITIZE_SPECIAL_CHARS );
 		$ref   = filter_input( INPUT_GET, Qliro_One_Callback_Auth::REF_PARAM, FILTER_SANITIZE_SPECIAL_CHARS );
 
+		// Resolve the order from the signed reference (or the confirmation id, for orders
+		// whose callback URL was registered with Qliro before it was signed), never from
+		// the request body.
+		$reference = ! empty( $token ) ? $ref : $confirmation_id;
+		$order     = qliro_get_order_by_confirmation_id( $reference );
+		if ( empty( $order ) ) {
+			Qliro_One_Logger::log( "[CALLBACK OM]: Skipping preauthorization callback for merchant reference #{$order_number} as no matching order was found for the reference." );
+			throw new Exception( 'order not found', 404 );
+		}
+
+		// Ignore preauthorization requests for non-subscription orders. Qliro sends this
+		// callback for ordinary orders too, and answering those 401 would tell it the push
+		// failed. Nothing is written on this path, so it is checked before authenticating.
+		$is_subscription = ! empty( $order->get_meta( Qliro_One_Subscriptions::PENDING_PREAUTHORIZATION ) );
+		if ( ! $is_subscription ) {
+			Qliro_One_Logger::log( "[CALLBACK OM]: Skipping preauthorization callback for merchant reference #{$order_number} as the order is not awaiting preauthorization." );
+			return;
+		}
+
+		// Authenticate before acting on the order, honouring a grace period for orders whose
+		// callback URL was registered unsigned.
 		if ( empty( $token ) ) {
 			Qliro_One_Logger::log( "[CALLBACK OM]: Preauthorization callback for merchant reference #{$order_number} arrived without an authentication token. Enabled via the 'qliro_one_allow_unauthenticated_callbacks' filter if you have issues with legacy orders." );
 
@@ -255,21 +275,6 @@ class Qliro_One_Callbacks {
 		} elseif ( ! Qliro_One_Callback_Auth::is_valid_token( $ref, $token ) ) {
 			Qliro_One_Logger::log( "[CALLBACK OM]: Rejected preauthorization callback for merchant reference #{$order_number} due to an invalid authentication token." );
 			throw new Exception( 'invalid callback token', 401 );
-		}
-
-		// Resolve the order from the signed reference (or the confirmation id during the grace period), never from the request body.
-		$reference = ! empty( $token ) ? $ref : $confirmation_id;
-		$order     = qliro_get_order_by_confirmation_id( $reference );
-		if ( empty( $order ) ) {
-			Qliro_One_Logger::log( "[CALLBACK OM]: Skipping preauthorization callback for merchant reference #{$order_number} as no matching order was found for the reference." );
-			throw new Exception( 'order not found', 404 );
-		}
-
-		// Ignore preauthorization request for non-subscription orders.
-		$is_subscription = ! empty( $order->get_meta( Qliro_One_Subscriptions::PENDING_PREAUTHORIZATION ) );
-		if ( ! $is_subscription ) {
-			Qliro_One_Logger::log( "[CALLBACK OM]: Skipping preauthorization callback for merchant reference #{$order_number} as the order is not awaiting preauthorization." );
-			return;
 		}
 
 		// Re-fetch the order from Qliro and read the preauthorization outcome from the API instead of the callback body.

--- a/classes/requests/helpers/class-qliro-one-merchant-urls.php
+++ b/classes/requests/helpers/class-qliro-one-merchant-urls.php
@@ -125,6 +125,10 @@ class Qliro_One_Merchant_URLS {
 	 *
 	 * URL of the push callback page for Order Management status changes.
 	 *
+	 * Signed with the confirmation id: the preauthorization callback authenticates
+	 * on this token and resolves the order from the signed reference, so the URL
+	 * must carry it however the Qliro order was created — checkout or renewal.
+	 *
 	 * @param string $rand_string A random string generated on creation that will follow the entire order process.
 	 * @return string
 	 */
@@ -135,6 +139,8 @@ class Qliro_One_Merchant_URLS {
 			),
 			home_url( '/wc-api/QOC_OM_Status/' )
 		);
+
+		$om_push_url = Qliro_One_Callback_Auth::add_token( $om_push_url, $rand_string );
 
 		return apply_filters( 'qliro_one_wc_om_push_url', $om_push_url );
 	}

--- a/classes/requests/post/class-qliro-one-request-create-merchant-payment.php
+++ b/classes/requests/post/class-qliro-one-request-create-merchant-payment.php
@@ -51,10 +51,7 @@ class Qliro_One_Request_Create_Merchant_Payment extends Qliro_One_Request_Post {
 			'Currency'                             => $order->get_currency(),
 			'Country'                              => $order->get_billing_country(),
 			'Language'                             => str_replace( '_', '-', strtolower( get_locale() ) ),
-			'MerchantOrderManagementStatusPushUrl' => Qliro_One_Callback_Auth::add_token(
-				QLIRO_WC()->merchant_urls->get_om_push_url( $confirm_id ),
-				$confirm_id
-			),
+			'MerchantOrderManagementStatusPushUrl' => QLIRO_WC()->merchant_urls->get_om_push_url( $confirm_id ),
 			'OrderItems'                           => $order_data::get_order_items( $this->arguments['order_id'] ),
 			'BillingAddress'                       => array(
 				'FirstName'  => $order->get_billing_first_name(),


### PR DESCRIPTION
Found while running test purchases against a live Qliro test merchant: **every ordinary order logs an authentication failure and answers Qliro's push with HTTP 401.**

```
[CALLBACK OM]: Received preauthorization callback for merchant reference #c345befa-38.
[CALLBACK OM]: Preauthorization callback … arrived without an authentication token.
[CALLBACK OM]: Processing error: missing callback token
```

## Cause

`9d0c817` made `complete_preauthorization()` require a signed token in the callback URL. Only one of the two paths that register that URL with Qliro was signing it:

| Registers `MerchantOrderManagementStatusPushUrl` | Signed before this PR |
|---|---|
| `class-qliro-one-request-create-merchant-payment.php` (subscription renewals) | Yes |
| `class-qliro-one-request-create-order.php:84` (cart checkout) | **No** |
| `class-qliro-one-request-create-order.php:163` (pay-for-order) | **No** |

`get_om_push_url()` added only `qliro_one_confirm_id`. Qliro sends a `Preauthorization` callback for ordinary orders as well, so those callbacks reached a handler demanding a token their URL never carried.

## Impact

No preauthorization was actually lost: `PENDING_PREAUTHORIZATION` is only set on renewal orders (`class-qliro-one-subscriptions.php:102`, `:163`), and those were signed. An ordinary order would have been skipped as "not awaiting preauthorization" anyway. What it did cost:

- `om_push_cb` answers **401** instead of `200 {"CallbackResponse":"received"}`, so Qliro treats the push as failed and retries it.
- Every purchase writes an auth error to the log — which is how a genuine one gets ignored.
- It is one meta-write away from a real failure, the moment a checkout-created order legitimately awaits preauthorization.

## Changes

1. **`get_om_push_url()` signs with the confirmation id** — the reference `complete_preauthorization()` resolves the order by, and the one the renewal path already signed. Both call sites inherit it; the `qliro_one_wc_om_push_url` filter still applies last.
2. **The renewal call site drops its now-redundant `add_token()` wrapper**, so there is one place that knows the URL is signed.
3. **`complete_preauthorization()` resolves the order and returns early for orders not awaiting preauthorization, before requiring the token.** That path writes nothing, so authenticating it bought nothing — and skipping first means orders whose URL was registered unsigned (everything placed before this PR) stop answering 401 without anyone reaching for `qliro_one_allow_unauthenticated_callbacks`. Acting on a subscription order still requires a valid signature.

## Verified against the live test merchant

The registered URL is now signed — from the create-order request body:

```
…/wc-api/QOC_OM_Status/?qliro_one_confirm_id=32b71408-…&qliro_callback_ref=32b71408-…&qliro_callback_token=5ceb9af8…
```

Replaying a `Preauthorization` callback for a real, non-subscription order in all three shapes:

| Callback | Before | After |
|---|---|---|
| signed, valid token | 401 | **200** `{"CallbackResponse":"received"}` |
| unsigned (legacy URL) | 401 | **200**, same |
| invalid token | 401 | **200**, same |

each logging `Skipping preauthorization callback … as the order is not awaiting preauthorization` and no `Processing error`.

## What I could not exercise

The subscription path itself — it needs WooCommerce Subscriptions and a card token. That code is unchanged apart from where the token check sits, and it still runs before the API re-fetch that mutates the order.

Worth a reviewer's eye: an unauthenticated caller can now distinguish "unknown reference" (404) from "known, not awaiting preauthorization" (200) where both previously returned 401. Both responses are inert and confirmation ids are random UUIDs, so I judged that an acceptable trade for not answering Qliro 401 on every order — but it is a deliberate change in what an unauthenticated caller can observe.