### PR TITLE
Queue API error notices so they can't block a redirect

### DIFF
--- a/.changelogs/2026-07-31-fix-api-error-blocks-redirect
+++ b/.changelogs/2026-07-31-fix-api-error-blocks-redirect
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a failed Qliro API call leaving the customer on a page containing nothing but the raw error text. API errors were printed as a notice the moment they occurred, which starts the response output — and once output has started no redirect can be sent. On the confirmation page, which runs before the page is rendered and then redirects to the thank-you page, that turned a failed confirmation into a bare error string with no layout and no redirect. Errors raised before rendering are now queued as a WooCommerce notice instead, so the redirect goes through and the customer sees the message on the page they land on. Errors raised while a template is rendering are still printed in place, unchanged.

--- a/includes/qliro-one-functions.php
+++ b/includes/qliro-one-functions.php
@@ -112,6 +112,20 @@ function qliro_one_print_error_message( $wp_error ) {
 		$error_message = implode( ' ', $error_message );
 	}
 
+	/**
+	 * Queue the notice while nothing has been sent yet.
+	 *
+	 * Printing starts output, and any redirect that follows is then impossible —
+	 * the confirmation page runs on init and redirects to the thank-you page, so
+	 * printing there leaves the customer on a bare error string instead. A queued
+	 * notice reaches them on the next rendered page either way. Once output has
+	 * begun we are inside a template and printing in place is what's wanted.
+	 */
+	if ( ! headers_sent() && did_action( 'woocommerce_init' ) && function_exists( 'wc_add_notice' ) ) {
+		wc_add_notice( $error_message, 'error' );
+		return;
+	}
+
 	if ( is_ajax() && function_exists( 'wc_add_notice' ) ) {
 			wc_add_notice( $error_message, 'error' );
 	} elseif ( function_exists( 'wc_print_notice' ) ) {


### PR DESCRIPTION
Found while testing #233 and #234 against a live Qliro test merchant. A confirmation that fails at Qliro's end leaves the customer on a **126-byte page containing nothing but the raw API error**:

```
Evaluation, No successful payment for the order 5525171
```

No layout, no styling, no redirect.

## Cause

`Qliro_One_API::check_for_api_error()` (`classes/class-qliro-one-api.php:249-253`) hands every non-admin, non-REST `WP_Error` to `qliro_one_print_error_message()`, whose non-AJAX branch calls `wc_print_notice()` — which **echoes immediately**. Thirteen API methods route through it.

Printing starts the response, and once output has begun no redirect can be sent. The confirmation page is exactly that case: `Qliro_One_Confirmation::confirm_order()` runs on `init` at priority 999 and then redirects to the thank-you page. The log names it:

```
PHP Warning: Cannot modify header information - headers already sent by
(output started at …/woocommerce/includes/wc-notice-functions.php)
```

This is **not** the same bug as #233. That one fixed how the redirect header was written; here output has already started, so `wp_safe_redirect()` is equally powerless — it warns and returns.

## Fix

One function. The question that matters is not whether the request is AJAX but whether output has started:

```php
if ( ! headers_sent() && did_action( 'woocommerce_init' ) && function_exists( 'wc_add_notice' ) ) {
    wc_add_notice( $error_message, 'error' );
    return;
}
```

Errors raised before rendering are queued and the redirect proceeds; errors raised while a template renders still print in place, because `headers_sent()` is true by then. The `did_action( 'woocommerce_init' )` guard keeps `wc_add_notice()` from running before WooCommerce's session exists, which would trip `_doing_it_wrong()`. The AJAX branch is untouched.

All four call sites inherit it — `class-qliro-one-api.php:251`, `class-qliro-one-checkout.php:142`, `includes/qliro-one-functions.php:41`.

## Verified on a live site, same request before and after

Reproduction: a checkout that creates the WooCommerce order but never completes payment in the iframe, then a request to `/checkout/?qliro_one_confirm_page=<confirmation id>`.

| | Before | After |
|---|---|---|
| Status | `200` | **`302`** |
| `location` | *(absent)* | `…/checkout/order-received/36/?key=…` |
| `x-redirect-by` | — | `WordPress` |
| Body | 126 bytes of raw notice markup | empty |
| `debug.log` | `Cannot modify header information` | *(no new warnings)* |

Following the redirect lands on the thank-you page in one hop, and the error survives as a proper WooCommerce notice — confirmed present in the session and rendered as `woocommerce-error` markup with the message intact on the next page that outputs notices.

## One thing a reviewer should weigh

WooCommerce's `order-received` template does not output notices, so on the thank-you page itself the queued error is not displayed — it appears on the next page that renders notices (cart, checkout, shop). That is strictly better than the previous bare error string with no redirect, but if a failed confirmation should *tell* the customer something on the page they land on, that needs a deliberate choice about where to send them.

Related: `confirm_order()` redirects to the order-received page regardless of whether confirmation succeeded, so a failed payment currently lands on a thank-you page. Pre-existing behaviour, untouched here, but worth its own look.