### PR TITLE
Add token in get_om_push_url call

### DIFF
--- a/classes/class-qliro-one-callbacks.php
+++ b/classes/class-qliro-one-callbacks.php
@@ -239,7 +239,7 @@ class Qliro_One_Callbacks {
 	 * @return void
 	 */
 	public function complete_preauthorization( $data, $confirmation_id ) {
-		$order_number = $data['MerchantReference'] ?? '';
+		$order_number = sanitize_text_field( $data['MerchantReference'] ?? '' );
 
 		// Authenticate the callback using the per-order token in the URL, honouring a grace period for legacy renewal orders.
 		$token = filter_input( INPUT_GET, Qliro_One_Callback_Auth::TOKEN_PARAM, FILTER_SANITIZE_SPECIAL_CHARS );

--- a/classes/requests/helpers/class-qliro-one-merchant-urls.php
+++ b/classes/requests/helpers/class-qliro-one-merchant-urls.php
@@ -136,6 +136,8 @@ class Qliro_One_Merchant_URLS {
 			home_url( '/wc-api/QOC_OM_Status/' )
 		);
 
+		$om_push_url = Qliro_One_Callback_Auth::add_token( $om_push_url, $rand_string );
+
 		return apply_filters( 'qliro_one_wc_om_push_url', $om_push_url );
 	}
 }


### PR DESCRIPTION
Implements the needed changes from this PR, together with a sanitization fix: https://github.com/krokedil/qliro-for-woocommerce/pull/234/

Resolves issue with included enhancement of the 2.2.9 release, so no changelog is included in this merge.