### PR TITLE
Skip the shipping order line until a method is chosen

### DIFF
--- a/.changelogs/2026-08-07-shipping-warning-no-chosen-method
+++ b/.changelogs/2026-08-07-shipping-warning-no-chosen-method
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a PHP warning that was logged during checkout when no shipping method had been selected yet, which happens when the store hides shipping costs until an address is entered.

--- a/classes/requests/helpers/class-qliro-one-helper-cart.php
+++ b/classes/requests/helpers/class-qliro-one-helper-cart.php
@@ -187,9 +187,15 @@ class Qliro_One_Helper_Cart {
 	 * @return array|null
 	 */
 	public static function get_shipping() {
-		$packages        = WC()->shipping()->get_packages();
 		$chosen_methods  = WC()->session->get( 'chosen_shipping_methods' );
-		$chosen_shipping = $chosen_methods[0];
+		$chosen_shipping = is_array( $chosen_methods ) ? ( $chosen_methods[0] ?? null ) : null;
+
+		// WooCommerce does not store a chosen shipping method until shipping has been calculated. With "Hide shipping costs until an address is entered" enabled, that does not happen until the customer has entered an address, leaving nothing for us to match against.
+		if ( null === $chosen_shipping ) {
+			return null;
+		}
+
+		$packages = WC()->shipping()->get_packages();
 		foreach ( $packages as $i => $package ) {
 			foreach ( $package['rates'] as $method ) {
 				$method_cost = qliro_ensure_numeric( $method->cost );


### PR DESCRIPTION
WC does not store a chosen shipping method until shipping has been calculated, so the session value was null when the store hides shipping costs until an address is entered. Indexing it emitted a PHP warning on every checkout load before the customer entered an address.

https://app.clickup.com/t/2423261/869ed0bgp