### PR TITLE
Query scheduled actions by indexed args match, shorten metabox text

### DIFF
--- a/classes/class-qliro-one-metabox.php
+++ b/classes/class-qliro-one-metabox.php
@@ -90,24 +90,23 @@ class Qliro_One_Metabox extends OrderMetabox {
 
 		$confirmation_id = $order->get_meta( '_qliro_one_order_confirmation_id' );
 		if ( ! empty( $confirmation_id ) ) {
-			$scheduled_actions = Qliro_Scheduled_Actions::get_scheduled_actions( $confirmation_id, gmdate( 'Y-m-d H:i:s', $order->get_date_created()->getTimestamp() ) );
+			$scheduled_actions = Qliro_Scheduled_Actions::get_scheduled_actions( $confirmation_id );
 			$completed_count   = count( $scheduled_actions['complete'] );
 			$failed_count      = count( $scheduled_actions['failed'] );
 			$pending_count     = count( $scheduled_actions['pending'] );
-			/* translators: 1: completed actions count, 2: failed actions count, 3: pending actions count. */
-			$link_text = sprintf(
-				__( '%1$s completed, %2$s failed, %3$s pending in the last three months.', 'qliro-for-woocommerce' ),
+			$link_text         = sprintf(
+				/* translators: 1: completed actions count, 2: failed actions count, 3: pending actions count. */
+				__( '%1$s completed, %2$s failed, %3$s pending', 'qliro-for-woocommerce' ),
 				number_format_i18n( $completed_count ),
 				number_format_i18n( $failed_count ),
 				number_format_i18n( $pending_count )
 			);
-			$link_url  = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
+			$link_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=' . rawurlencode( $confirmation_id ) . '&action=-1&paged=1&action2=-1' );
 
 			self::output_info(
 				__( 'Scheduled actions', 'qliro-for-woocommerce' ),
-				esc_html( $link_text ) . '<br><a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . __( 'View all scheduled actions', 'qliro-for-woocommerce' ) . '</a><br>'
+				'<a target="_blank" rel="noopener noreferrer" href="' . esc_url( $link_url ) . '">' . esc_html( $link_text ) . '</a>'
 			);
-
 		}
 
 		echo '<br />';

--- a/classes/class-qliro-scheduled-actions.php
+++ b/classes/class-qliro-scheduled-actions.php
@@ -16,10 +16,9 @@ class Qliro_Scheduled_Actions {
 	 * Gets the scheduled actions for the order.
 	 *
 	 * @param string $confirmation_id The confirmation ID.
-	 * @param string $order_created_date The order creation date.
 	 * @return array
 	 */
-	public static function get_scheduled_actions( $confirmation_id, $order_created_date ) {
+	public static function get_scheduled_actions( $confirmation_id ) {
 		$statuses          = array( 'complete', 'failed', 'pending' );
 		$scheduled_actions = array(
 			'complete' => array(),
@@ -27,23 +26,17 @@ class Qliro_Scheduled_Actions {
 			'pending'  => array(),
 		);
 
-		$order_created_timestamp = strtotime( $order_created_date );
-		$three_months_ago        = strtotime( '-3 months' );
-
-		if ( $order_created_timestamp >= $three_months_ago ) {
-			foreach ( $statuses as $status ) {
-				$scheduled_actions[ $status ] = as_get_scheduled_actions(
-					array(
-						'search'       => $confirmation_id,
-						'status'       => array( $status ),
-						'per_page'     => -1,
-						'group'        => Qliro_One_Callbacks::CHECKOUT_CALLBACKS,
-						'date'         => $order_created_date,
-						'date_compare' => '>=',
-					),
-					'ids'
-				);
-			}
+		foreach ( $statuses as $status ) {
+			$scheduled_actions[ $status ] = as_get_scheduled_actions(
+				array(
+					// Exact args match is indexed in Action Scheduler, unlike the LIKE-based 'search' parameter.
+					'args'     => array( $confirmation_id ),
+					'status'   => array( $status ),
+					'per_page' => -1,
+					'group'    => Qliro_One_Callbacks::CHECKOUT_CALLBACKS,
+				),
+				'ids'
+			);
 		}
 
 		return $scheduled_actions;


### PR DESCRIPTION
Targets #221.

## Why

The review concern about querying all actions was valid, but the expensive part is the `'search'` parameter, not the missing date bound. Action Scheduler compiles `search` to a leading-wildcard `LIKE '%<id>%'` on `hook`/`args`/`extended_args`, which cannot use any index and scans the `actionscheduler_actions` table — three times, once per status.

Since the callbacks are scheduled with exactly `array( $confirmation_id )` as args, we can use `'args' => array( $confirmation_id )` instead. That compiles to an exact `a.args = '["<id>"]'` match, which uses the `args` column index ([`KEY args(191)`, part of the Action Scheduler custom-tables schema since 3.0.0](https://github.com/woocommerce/action-scheduler/blob/3.0.0/classes/schema/ActionScheduler_StoreSchema.php) — bundled with WooCommerce since 4.0, so covered by this plugin's WC 5.0 minimum). The lookup is fast regardless of table size or order age, so the 3-month cutoff is no longer needed.

Two side benefits:

- **"In the last three months" was inaccurate anyway** — Action Scheduler purges completed/canceled actions after 31 days by default (`action_scheduler_retention_period`), so the completed count never spans three months.
- **No more misleading zeros for old orders** — previously, orders older than 3 months skipped the query but still rendered "0 completed, 0 failed, 0 pending in the last three months." Now the counts are always real.

## Changes

- `Qliro_Scheduled_Actions::get_scheduled_actions()` queries by exact `args` match; the `$order_created_date` parameter, the 3-month skip, and the `date`/`date_compare` args are removed. The group filter is kept.
- The metabox shows the counts themselves as the link (back to the original short form): **1 completed, 0 failed, 0 pending** — no qualifier sentence or separate link line. The counts match what the linked Action Scheduler page shows, since both reflect the same retention window.
- Moved the `translators:` comment directly above the `__()` call, fixing one of the PHPCS errors on the base branch. PHPCS passes clean on both changed files.
