### PR TITLE
Improve return fee clarity for merchants and customers

### DIFF
--- a/.changelogs/2026-08-13-return-fee-clarity
+++ b/.changelogs/2026-08-13-return-fee-clarity
@@ -1,4 +1,4 @@
 Type: Enhancement
 Needs Documentation: yes
 
-Improved return fee clarity on refunds. The order admin now shows how the fee affects the refunded amount, and the customer is informed about the deducted fee in refund emails and on the My Account order page.
+The return fee on refunds is now explained in the order admin, and shown to the customer in refund emails and on the My Account page.

--- a/.changelogs/2026-08-13-return-fee-clarity
+++ b/.changelogs/2026-08-13-return-fee-clarity
@@ -1,4 +1,4 @@
 Type: Enhancement
 Needs Documentation: yes
 
-Clearer return fee handling on refunds. The order admin now shows how the return fee affects the refund (refund value, return fee and the amount refunded to the customer) along with a return fee total on the order, and the customer is informed about the deducted fee in refund emails and on the My Account order page.
+Improved return fee clarity on refunds. The order admin now shows how the fee affects the refunded amount, and the customer is informed about the deducted fee in refund emails and on the My Account order page.

--- a/.changelogs/2026-08-13-return-fee-clarity
+++ b/.changelogs/2026-08-13-return-fee-clarity
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: yes
+
+Clearer return fee handling on refunds. The order admin now shows how the return fee affects the refund (refund value, return fee and the amount refunded to the customer) along with a return fee total on the order, and the customer is informed about the deducted fee in refund emails and on the My Account order page.

--- a/assets/js/admin-order.js
+++ b/assets/js/admin-order.js
@@ -300,8 +300,14 @@ jQuery(function ($) {
 				return;
 			}
 
-			// Update the button text with the return fee amount by replacing inner text of the span#qliro_return_fee_total with the refund fee amount.
-			$qliroReturnFeeTotalSpan.text(' (' + qoc_admin_params.minus_return_fee_text + ' ' + qoc.format_number(refundFeeAmount) + ')' );
+			// The return fee is not part of the refund amount, so it is what the customer gets back that is reduced.
+			const paidBackAmount = qoc.unformat_number($('#refund_amount').val()) - refundFeeAmount;
+
+			// Spell out the fee and the amount paid back in the refund button text.
+			$qliroReturnFeeTotalSpan.text(' ' + qoc_admin_params.return_fee_summary_text
+				.replace('%1$s', qoc.format_number(refundFeeAmount))
+				.replace('%2$s', qoc.format_number(paidBackAmount))
+			);
 		},
 
 		format_number: function (number) {

--- a/assets/js/admin-order.js
+++ b/assets/js/admin-order.js
@@ -276,6 +276,10 @@ jQuery(function ($) {
 				return;
 			}
 
+			// Clear any entered return fee so the refund button text does not keep a stale suffix.
+			$qliroReturnFee.find('input.refund_line_total.wc_input_price, input.refund_line_tax.wc_input_price').val('');
+			qoc.update_qliro_refund_amount();
+
 			$qliroReturnFee.hide();
 		},
 
@@ -297,8 +301,7 @@ jQuery(function ($) {
 			}
 
 			// Update the button text with the return fee amount by replacing inner text of the span#qliro_return_fee_total with the refund fee amount.
-			//$qliroReturnFeeTotalSpan.text( qoc_admin_params.return_fee_text + ' ' + accounting.formatMoney(refundFeeAmount, {
-			$qliroReturnFeeTotalSpan.text(' (' + qoc_admin_params.with_return_fee_text + ' ' + qoc.format_number(refundFeeAmount) + ')' );
+			$qliroReturnFeeTotalSpan.text(' (' + qoc_admin_params.minus_return_fee_text + ' ' + qoc.format_number(refundFeeAmount) + ')' );
 		},
 
 		format_number: function (number) {
@@ -357,6 +360,7 @@ jQuery(function ($) {
 				.ready(this.modify_refund_button_text)
 				.on('change', '#refund_amount', this.update_qliro_refund_amount)
 				.on('change', '#qliro_return_fee input.refund_line_total.wc_input_price', this.update_qliro_refund_amount)
+				.on('change', '#qliro_return_fee input.refund_line_tax.wc_input_price', this.update_qliro_refund_amount)
 
 			window.addEventListener("hashchange", qoc.showListOfDeliveries);
 		}

--- a/classes/class-qliro-one-assets.php
+++ b/classes/class-qliro-one-assets.php
@@ -193,8 +193,8 @@ class Qliro_One_Assets {
 			'captured_items'                          => ! empty( $captured_items ) ? wp_json_encode( $captured_items ) : '{}',
 			'shipping_checkbox_text'                  => __( 'Check this checkbox to include this shipping line in this capture.', 'qliro-for-woocommerce' ),
 			'fee_checkbox_text'                       => __( 'Check this checkbox to include this fee line in this capture.', 'qliro-for-woocommerce' ),
-			'with_return_fee_text'                    => __( 'with a return fee of', 'qliro-for-woocommerce' ),
-			'refund_amount_less_than_return_fee_text' => __( 'Refund amount is less than the return fee.', 'qliro-for-woocommerce' ),
+			'minus_return_fee_text'                   => __( 'minus a return fee of', 'qliro-for-woocommerce' ),
+			'refund_amount_less_than_return_fee_text' => __( 'The return fee cannot be higher than the refund amount.', 'qliro-for-woocommerce' ),
 			'i18n'                                    => array(
 				'makeCaptureFailed' => __( 'An error occurred while making the capture. Please try again.', 'qliro-for-woocommerce' ),
 				'dismissNotice'     => __( 'Dismiss this notice', 'qliro-for-woocommerce' ),

--- a/classes/class-qliro-one-assets.php
+++ b/classes/class-qliro-one-assets.php
@@ -193,7 +193,8 @@ class Qliro_One_Assets {
 			'captured_items'                          => ! empty( $captured_items ) ? wp_json_encode( $captured_items ) : '{}',
 			'shipping_checkbox_text'                  => __( 'Check this checkbox to include this shipping line in this capture.', 'qliro-for-woocommerce' ),
 			'fee_checkbox_text'                       => __( 'Check this checkbox to include this fee line in this capture.', 'qliro-for-woocommerce' ),
-			'minus_return_fee_text'                   => __( 'minus a return fee of', 'qliro-for-woocommerce' ),
+			// translators: 1: the return fee amount, 2: the amount paid back to the customer.
+			'return_fee_summary_text'                 => __( '(return fee %1$s deducted, %2$s paid back)', 'qliro-for-woocommerce' ),
 			'refund_amount_less_than_return_fee_text' => __( 'The return fee cannot be higher than the refund amount.', 'qliro-for-woocommerce' ),
 			'i18n'                                    => array(
 				'makeCaptureFailed' => __( 'An error occurred while making the capture. Please try again.', 'qliro-for-woocommerce' ),

--- a/classes/class-qliro-one-fields.php
+++ b/classes/class-qliro-one-fields.php
@@ -346,7 +346,7 @@ class Qliro_One_Fields {
 				'label'       => __( 'Automatically calculate return fee on refunds', 'qliro-for-woocommerce' ),
 				'type'        => 'checkbox',
 				'default'     => 'no',
-				'description' => __( 'If enabled, then the Qliro return fee will be automatically calculated in the background if a refunded order line is less than the unit amount.', 'qliro-for-woocommerce' ),
+				'description' => __( 'If enabled and you refund an order line at a lower amount than its original price, the difference is automatically sent to Qliro as a return fee. The fee is deducted from the amount Qliro pays back to the customer and is shown on the order and in the customer\'s refund details.', 'qliro-for-woocommerce' ),
 				'desc_tip'    => true,
 			),
 			'om_advanced_settings'                       => array(

--- a/classes/class-qliro-one-fields.php
+++ b/classes/class-qliro-one-fields.php
@@ -142,8 +142,8 @@ class Qliro_One_Fields {
 				'title'       => __( 'Advanced demo mode', 'qliro-for-woocommerce' ),
 				'label'       => __( 'Enable advanced demo mode', 'qliro-for-woocommerce' ),
 				'type'        => 'checkbox',
-				/* translators: 1: WooCommerce coupon settings link, 2: documentation link */
 				'description' => sprintf(
+					/* translators: 1: WooCommerce coupon settings link, 2: documentation link */
 					__( 'Configure coupons in %1$s. For detailed instructions, see the %2$s.', 'qliro-for-woocommerce' ),
 					'<a target="_blank" href="' . admin_url( 'edit.php?post_type=shop_coupon' ) . '">' . __( 'WooCommerce coupon settings', 'qliro-for-woocommerce' ) . '</a>',
 					'<a target="_blank" href="https://docs.krokedil.com/qliro-for-woocommerce/get-started/advanced-demo-mode/">' . __( 'documentation', 'qliro-for-woocommerce' ) . '</a>'
@@ -306,7 +306,6 @@ class Qliro_One_Fields {
 				'type'              => 'number',
 				'css'               => 'width: 100px',
 				'description'       => __( 'Set the max amount above the order value a customer can add to a Qliro order paid with a After Delivery payment. If you want higher than 10% you will first need to contact Qliro. Read more about upsell <a target="_blank" href="https://docs.krokedil.com/post-purchase-upsell-for-woocommerce/">here</a>.', 'qliro-for-woocommerce' ),
-				'default'           => '',
 				'desc_tip'          => false,
 				'default'           => 10,
 				'class'             => 'krokedil_ppu_setting' . $ppu_status,

--- a/classes/class-qliro-one-fields.php
+++ b/classes/class-qliro-one-fields.php
@@ -145,8 +145,8 @@ class Qliro_One_Fields {
 				'description' => sprintf(
 					/* translators: 1: WooCommerce coupon settings link, 2: documentation link */
 					__( 'Configure coupons in %1$s. For detailed instructions, see the %2$s.', 'qliro-for-woocommerce' ),
-					'<a target="_blank" href="' . admin_url( 'edit.php?post_type=shop_coupon' ) . '">' . __( 'WooCommerce coupon settings', 'qliro-for-woocommerce' ) . '</a>',
-					'<a target="_blank" href="https://docs.krokedil.com/qliro-for-woocommerce/get-started/advanced-demo-mode/">' . __( 'documentation', 'qliro-for-woocommerce' ) . '</a>'
+					'<a target="_blank" rel="noopener noreferrer" href="' . admin_url( 'edit.php?post_type=shop_coupon' ) . '">' . __( 'WooCommerce coupon settings', 'qliro-for-woocommerce' ) . '</a>',
+					'<a target="_blank" rel="noopener noreferrer" href="https://docs.krokedil.com/qliro-for-woocommerce/get-started/advanced-demo-mode/">' . __( 'documentation', 'qliro-for-woocommerce' ) . '</a>'
 				),
 				'default'     => 'no',
 				'desc_tip'    => false,

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -608,7 +608,7 @@ class Qliro_One_Order_Management {
 
 		$return_fee_info = sprintf(
 			// translators: 1: the return fee amount, 2: the amount refunded to the customer.
-			__( 'A return fee of %1$s was deducted from this refund. %2$s was refunded to you.', 'qliro-for-woocommerce' ),
+			__( 'Return fee: %1$s — %2$s refunded to you.', 'qliro-for-woocommerce' ),
 			wc_price( $fee_total, $currency ),
 			wc_price( $refunded_to_customer, $currency )
 		);

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -607,8 +607,8 @@ class Qliro_One_Order_Management {
 		$refunded_to_customer = abs( $refund->get_total() + $fee_totals['manual'] );
 
 		$return_fee_info = sprintf(
-			// translators: 1: the return fee amount, 2: the amount refunded to the customer.
-			__( 'Return fee %1$s deducted, %2$s refunded to you.', 'qliro-for-woocommerce' ),
+			// translators: 1: the return fee amount, 2: the amount paid back to the customer.
+			__( 'Return fee %1$s deducted, %2$s paid back to you.', 'qliro-for-woocommerce' ),
 			wc_price( $fee_total, $currency ),
 			wc_price( $refunded_to_customer, $currency )
 		);

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -608,7 +608,7 @@ class Qliro_One_Order_Management {
 
 		$return_fee_info = sprintf(
 			// translators: 1: the return fee amount, 2: the amount refunded to the customer.
-			__( 'Return fee: %1$s — %2$s refunded to you.', 'qliro-for-woocommerce' ),
+			__( 'Return fee %1$s deducted, %2$s refunded to you.', 'qliro-for-woocommerce' ),
 			wc_price( $fee_total, $currency ),
 			wc_price( $refunded_to_customer, $currency )
 		);

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -408,7 +408,7 @@ class Qliro_One_Order_Management {
 
 			$formatted_text = sprintf(
 				// translators: 1: the total refund amount, 2: the return fee amount, 3: the amount paid back to the customer.
-				__( 'Processing a refund of %1$s with Qliro. A return fee of %2$s was deducted — %3$s will be paid back to the customer.', 'qliro-for-woocommerce' ),
+				__( 'Processing a refund of %1$s with Qliro. Return fee %2$s deducted, %3$s paid back to the customer.', 'qliro-for-woocommerce' ),
 				wc_price( $gross_amount, $currency ),
 				wc_price( $manual_fees + $calculated_fees, $currency ),
 				wc_price( $net_amount, $currency )

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -30,6 +30,8 @@ class Qliro_One_Order_Management {
 
 		add_action( 'woocommerce_admin_order_items_after_shipping', array( $this, 'add_return_fee_order_lines_html' ), PHP_INT_MAX );
 		add_action( 'woocommerce_after_order_refund_item_name', array( $this, 'show_return_fee_info' ) );
+		add_action( 'woocommerce_admin_order_totals_after_refunded', array( $this, 'add_return_fee_to_order_totals_summary' ) );
+		add_filter( 'woocommerce_order_refund_get_reason', array( $this, 'add_return_fee_info_to_refund_reason' ), 10, 2 );
 
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'maybe_sync_order' ), 9999, 2 );
 
@@ -387,24 +389,35 @@ class Qliro_One_Order_Management {
 		}
 
 		$applied_return_fees = apply_filters( 'qliro_applied_return_fees', array() );
-
-		// translators: refund amount, refund id.
-		$text = __( 'Processing a refund of %1$s with Qliro', 'qliro-for-woocommerce' );
+		$currency            = array( 'currency' => $order->get_currency() );
 
 		if ( ! empty( $applied_return_fees ) ) {
-			$total_return_fees = 0;
+			$manual_fees     = 0;
+			$calculated_fees = 0;
 			foreach ( $applied_return_fees as $return_fee ) {
-				$total_return_fees += $return_fee['PricePerItemIncVat'] ?? 0;
+				if ( 'return-fee-calculated' === ( $return_fee['MerchantReference'] ?? '' ) ) {
+					$calculated_fees += floatval( $return_fee['PricePerItemIncVat'] ?? 0 );
+				} else {
+					$manual_fees += floatval( $return_fee['PricePerItemIncVat'] ?? 0 );
+				}
 			}
 
-			$formatted_total_return_fees = wc_price( $total_return_fees, array( 'currency' => $order->get_currency() ) );
+			// Manual fees are not included in the refund amount, while calculated fees already are.
+			$gross_amount = $amount + $calculated_fees;
+			$net_amount   = $amount - $manual_fees;
 
-			// translators: return frees amount.
-			$extra_text = sprintf( __( ' (including return fees of %1$s)', 'qliro-for-woocommerce' ), $formatted_total_return_fees );
-			$text      .= $extra_text;
+			$formatted_text = sprintf(
+				// translators: 1: the total refund amount, 2: the return fee amount, 3: the amount paid back to the customer.
+				__( 'Processing a refund of %1$s with Qliro. A return fee of %2$s was deducted — %3$s will be paid back to the customer.', 'qliro-for-woocommerce' ),
+				wc_price( $gross_amount, $currency ),
+				wc_price( $manual_fees + $calculated_fees, $currency ),
+				wc_price( $net_amount, $currency )
+			);
+		} else {
+			// translators: %1$s: the refund amount.
+			$formatted_text = sprintf( __( 'Processing a refund of %1$s with Qliro', 'qliro-for-woocommerce' ), wc_price( $amount, $currency ) );
 		}
 
-		$formatted_text = sprintf( $text, wc_price( $amount, array( 'currency' => $order->get_currency() ) ) );
 		$order->add_order_note( $formatted_text );
 
 		$refund_order = wc_get_order( $refund_order_id );
@@ -508,32 +521,166 @@ class Qliro_One_Order_Management {
 	}
 
 	/**
-	 * Show the return fee info in the refund order.
+	 * Show a breakdown of how the return fee affects the refund under the refund line in the order admin.
 	 *
-	 * @param WC_Order $refund_order The refund order..
+	 * @param WC_Order_Refund $refund_order The refund order.
 	 */
 	public function show_return_fee_info( $refund_order ) {
-		$return_fees = $refund_order->get_meta( '_qliro_return_fees' );
-		// If its empty, just return.
-		if ( empty( $return_fees ) ) {
+		$fee_totals = self::get_return_fee_totals_for_refund( $refund_order );
+		$fee_total  = $fee_totals['manual'] + $fee_totals['calculated'];
+
+		// If the total is 0, just return.
+		if ( $fee_total <= 0 ) {
 			return;
 		}
 
-		$total = 0;
-		foreach ( $return_fees as $return_fee ) {
-			$total += $return_fee['PricePerItemIncVat'] ?? 0;
+		$currency = array( 'currency' => $refund_order->get_currency() );
+		// The refund total is negative. Manual fees are not included in the refund total, while calculated fees already are.
+		$refund_value         = $refund_order->get_total() - $fee_totals['calculated'];
+		$refunded_to_customer = $refund_order->get_total() + $fee_totals['manual'];
+		?>
+		<span class="qliro-return-fee-info display_meta" style="display: block; margin-top: 10px; color: #888; font-size: .92em!important;">
+			<span style="font-weight: bold;"><?php esc_html_e( 'Refund value: ', 'qliro-for-woocommerce' ); ?></span>
+			<?php echo wp_kses_post( wc_price( $refund_value, $currency ) ); ?><br>
+			<span style="font-weight: bold;"><?php esc_html_e( 'Return fee: ', 'qliro-for-woocommerce' ); ?></span>
+			<?php echo wp_kses_post( wc_price( $fee_total, $currency ) ); ?><br>
+			<span style="font-weight: bold;"><?php esc_html_e( 'Refunded to customer: ', 'qliro-for-woocommerce' ); ?></span>
+			<?php echo wp_kses_post( wc_price( $refunded_to_customer, $currency ) ); ?>
+		</span>
+		<?php
+	}
+
+	/**
+	 * Show the total return fee for the order in the order totals summary, after the refunded row.
+	 *
+	 * @param int $order_id The WooCommerce order id.
+	 * @return void
+	 */
+	public function add_return_fee_to_order_totals_summary( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order || 'qliro_one' !== $order->get_payment_method() ) {
+			return;
 		}
 
-		// If the total is 0, just return.
-		if ( $total <= 0 ) {
+		$fee_total = self::get_return_fee_total_for_order( $order );
+		if ( $fee_total <= 0 ) {
 			return;
 		}
 		?>
-		<span class="qliro-return-fee-info display_meta" style="display: block; margin-top: 10px; color: #888; font-size: .92em!important;">
-			<span style="font-weight: bold;"><?php esc_html_e( 'Qliro return fee: ', 'qliro-for-woocommerce' ); ?></span>
-			<?php echo wp_kses_post( wc_price( $total, array( 'currency' => $refund_order->get_currency() ) ) ); ?>
-		</span>
+		<tr>
+			<td class="label"><?php esc_html_e( 'Return fee', 'qliro-for-woocommerce' ); ?>:</td>
+			<td width="1%"></td>
+			<td class="total"><?php echo wp_kses_post( wc_price( $fee_total, array( 'currency' => $order->get_currency() ) ) ); ?></td>
+		</tr>
 		<?php
+	}
+
+	/**
+	 * Add information about the deducted return fee to the refund reason shown to the customer.
+	 *
+	 * The reason is only modified while it is being rendered on the customer account page or in an
+	 * email to the customer, and is never persisted to the refund.
+	 *
+	 * @param string          $reason The refund reason.
+	 * @param WC_Order_Refund $refund The refund order.
+	 * @return string
+	 */
+	public function add_return_fee_info_to_refund_reason( $reason, $refund ) {
+		if ( ! $this->should_return_fee_info_be_shown() ) {
+			return $reason;
+		}
+
+		$order = wc_get_order( $refund->get_parent_id() );
+		if ( ! $order || 'qliro_one' !== $order->get_payment_method() ) {
+			return $reason;
+		}
+
+		$fee_totals = self::get_return_fee_totals_for_refund( $refund );
+		$fee_total  = $fee_totals['manual'] + $fee_totals['calculated'];
+		if ( $fee_total <= 0 ) {
+			return $reason;
+		}
+
+		$currency = array( 'currency' => $refund->get_currency() );
+		// Manual fees are not included in the refund total, so the amount paid back to the customer is the total minus the manual fees.
+		$refunded_to_customer = abs( $refund->get_total() + $fee_totals['manual'] );
+
+		$return_fee_info = sprintf(
+			// translators: 1: the return fee amount, 2: the amount refunded to the customer.
+			__( 'A return fee of %1$s was deducted from this refund. %2$s was refunded to you.', 'qliro-for-woocommerce' ),
+			wc_price( $fee_total, $currency ),
+			wc_price( $refunded_to_customer, $currency )
+		);
+
+		return empty( $reason ) ? $return_fee_info : $return_fee_info . '<br>' . $reason;
+	}
+
+	/**
+	 * Whether the return fee information should be added to the refund reason.
+	 *
+	 * Only when rendering the customer account page or an email to the customer, so the modified
+	 * reason is never displayed in the admin or saved with the refund.
+	 *
+	 * @return bool
+	 */
+	private function should_return_fee_info_be_shown() {
+		if ( is_account_page() ) {
+			return true;
+		}
+
+		if ( did_action( 'woocommerce_email_order_details' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the return fee totals for a refund, split by how the fee was added.
+	 *
+	 * Manual fees are entered in the return fee row and are not included in the refund total,
+	 * while calculated fees are the difference between the original and the refunded order line
+	 * amounts and are therefore already part of the refund total.
+	 *
+	 * @param WC_Order_Refund $refund_order The refund order.
+	 * @return array The return fee totals including VAT, keyed by 'manual' and 'calculated'.
+	 */
+	public static function get_return_fee_totals_for_refund( $refund_order ) {
+		$fee_totals = array(
+			'manual'     => 0,
+			'calculated' => 0,
+		);
+
+		$return_fees = $refund_order->get_meta( '_qliro_return_fees' );
+		if ( empty( $return_fees ) ) {
+			return $fee_totals;
+		}
+
+		foreach ( $return_fees as $return_fee ) {
+			$type = 'return-fee-calculated' === ( $return_fee['MerchantReference'] ?? '' ) ? 'calculated' : 'manual';
+
+			$fee_totals[ $type ] += floatval( $return_fee['PricePerItemIncVat'] ?? 0 );
+		}
+
+		return $fee_totals;
+	}
+
+	/**
+	 * Get the total return fee including VAT for all refunds on an order.
+	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 * @return float
+	 */
+	public static function get_return_fee_total_for_order( $order ) {
+		$total = 0;
+
+		foreach ( $order->get_refunds() as $refund_order ) {
+			$fee_totals = self::get_return_fee_totals_for_refund( $refund_order );
+			$total     += $fee_totals['manual'] + $fee_totals['calculated'];
+		}
+
+		return $total;
 	}
 
 	/**

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -33,7 +33,7 @@ class Qliro_One_Order_Management {
 		add_action( 'woocommerce_admin_order_totals_after_refunded', array( $this, 'add_return_fee_to_order_totals_summary' ) );
 		add_filter( 'woocommerce_order_refund_get_reason', array( $this, 'add_return_fee_info_to_refund_reason' ), 10, 2 );
 
-		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'maybe_sync_order' ), 9999, 2 );
+		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'maybe_sync_order' ), 9999 );
 
 		// Register the action to set the transaction meta data when reading the Qliro order from the admin endpoint.
 		add_action( 'qliro_admin_order_received', Qliro_Order_Utility::class . '::maybe_update_transaction_meta', 10, 2 );
@@ -722,10 +722,9 @@ class Qliro_One_Order_Management {
 	/**
 	 * Maybe sync the order with Qliro when the order is updated.
 	 *
-	 * @param int     $order_id The WooCommerce Order ID.
-	 * @param WP_Post $post The post object.
+	 * @param int $order_id The WooCommerce Order ID.
 	 */
-	public function maybe_sync_order( $order_id, $post ) {
+	public function maybe_sync_order( $order_id ) {
 
 		// If the order automatic sync on update is not enabled, bail.
 		if ( ! apply_filters( 'qliro_sync_order_on_update', false, $order_id ) ) {

--- a/classes/class-qliro-one-order-management.php
+++ b/classes/class-qliro-one-order-management.php
@@ -613,7 +613,8 @@ class Qliro_One_Order_Management {
 			wc_price( $refunded_to_customer, $currency )
 		);
 
-		return empty( $reason ) ? $return_fee_info : $return_fee_info . '<br>' . $reason;
+		// The space keeps the two apart in plain text emails, where the line break is stripped.
+		return empty( $reason ) ? $return_fee_info : $return_fee_info . ' <br>' . $reason;
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43,12 +43,6 @@ parameters:
 			path: classes/class-qliro-one-checkout.php
 
 		-
-			message: '#^Array has 2 duplicate keys with value ''default'' \(''default'', ''default''\)\.$#'
-			identifier: array.duplicateKey
-			count: 1
-			path: classes/class-qliro-one-fields.php
-
-		-
 			message: '#^Property Qliro_One_Gateway\:\:\$upsell_percentage \(int\) does not accept string\.$#'
 			identifier: assign.propertyType
 			count: 1


### PR DESCRIPTION
## What

Improves how the return fee on refunds is presented, so both merchants and customers understand what is deducted and what is actually paid back. Display/wording only — request bodies to Qliro and WC refund records are unchanged.

### Merchant-facing (order admin)
- The single "Qliro return fee: X" line under a refund is now a three-line breakdown: **Refund value / Return fee / Refunded to customer**.
- New **Return fee** row in the order totals summary (under *Refunded*), summed across all refunds.
- Refund button suffix now reads "(**minus** a return fee of 12,50 kr)" instead of "with a return fee of", updates when only the tax field changes, and is cleared when the refund is cancelled.
- Order note now states all three amounts: *"Processing a refund of 100,00 kr with Qliro. A return fee of 12,50 kr was deducted — 87,50 kr will be paid back to the customer."*
- Clearer "Calculate return fee" setting description and fee-too-high validation message.

### Customer-facing (new)
- Refund emails and My Account → view order now show under the refund row: *"A return fee of 12,50 kr was deducted from this refund. 87,50 kr was refunded to you."*
- Injected via the `woocommerce_order_refund_get_reason` filter, gated to `is_account_page()` / `did_action( 'woocommerce_email_order_details' )` — render-time only, never persisted, never shown in admin. Ported from the Klarna Payments plugin's `ReturnFee` implementation.

### Why the display math branches on `MerchantReference`
Manual fees (`return-fee`) are **not** part of the WC refund total (WC records the gross typed amount), while auto-calculated fees (`return-fee-calculated`) already are (the merchant typed reduced line amounts). The breakdown/note/customer line handle both, including mixed refunds.

## PR screenshots
<img width="3548" height="5918" alt="qliro-pr-245-return-fee-clarity" src="https://github.com/user-attachments/assets/99353a6a-3f51-450d-b837-0f6ca9edb098" />

## Testing

Verified in the repo's playground environment with seeded orders:
- Manual fee, two refunds on one order: breakdown per refund, totals row sums (22,50), email + My Account sentence with correct net amounts, original reason preserved after the fee sentence.
- Calculated fee: breakdown shows gross −100 / fee 12,50 / refunded −87,50 from a −87,50 refund record.
- Admin reason field never shows the injected customer text.
- JS: suffix wording, tax-field binding, cancel clears inputs and suffix.
- PHPCS: no new issues on changed lines.

Not covered: a live end-to-end refund against the Qliro sandbox (the order-note path); its math mirrors the verified breakdown logic.

## Notes
- A changelog entry is included in `.changelogs/` (required by CI); the `readme.txt` changelog and `.pot` regeneration happen at release time.
- The touched files also received three small pre-existing PHPCS fixes (translators comment placement, duplicate `default` array key + its stale PHPStan baseline entry, unused `$post` parameter), since CI runs PHPCS on whole changed files.
- A deeper rework (meta format, real `WC_Order_Item_Fee` on the refund with net totals) is planned as a follow-up step.
- Pre-existing bugs spotted during this work are being handled separately (legacy double refund request, `qliro_applied_return_fees` accumulator doubling, manual-refund button discarding a typed fee).
