### PR TITLE
Seed the full Qliro order-management settings in the playground config

### DIFF
--- a/playground.config.mjs
+++ b/playground.config.mjs
@@ -30,6 +30,23 @@ export default {
 	// output) are committed. Rebuild manually with `npm run build` when
 	// working on assets/js/ or assets/css/.
 
+	// setSiteOptions REPLACES each option wholesale, so this map is the entire
+	// gateway settings array — WooCommerce only writes the form_fields defaults
+	// when the settings screen is saved, and nothing here ever saves it. Keys
+	// omitted below are therefore absent from the DB, and the plugin reads some
+	// of them straight off `get_option( 'woocommerce_qliro_one_settings' )`
+	// without an isset()/default (see Qliro_One_Order_Management), so a missing
+	// key is an undefined-array-key warning plus wrong behavior — not a
+	// fallback to the documented default. Keep this in sync with the defaults
+	// in classes/class-qliro-one-fields.php.
+	//
+	// When this lands in the site: the blueprint (and with it setSiteOptions) is
+	// applied on FRESH PROVISION ONLY for the persistent `start` site — warm
+	// boots skip the blueprint entirely, which is what lets edits made in
+	// wp-admin survive a restart. Changes here therefore need
+	// `playground.mjs start --fresh` (resets site data) to take effect. The
+	// ephemeral `server development|demo` modes re-apply the blueprint on every
+	// run, so there they land on each boot and overwrite any admin edits.
 	options: {
 		all: {
 			woocommerce_qliro_one_settings: {
@@ -41,6 +58,44 @@ export default {
 				// unconfigured (the site still boots).
 				test_api_key: envSecret('QLIRO_TEST_API_KEY'),
 				test_api_secret: envSecret('QLIRO_TEST_API_SECRET'),
+
+				// Order management. Read unguarded by
+				// Qliro_One_Order_Management::order_status_changed(), so
+				// without these no status change ever matches and completing an
+				// order silently never captures (MarkItemsAsShipped) — which
+				// also hides the admin return-fee row, since it only renders on
+				// fully captured orders.
+				capture_status: 'wc-completed',
+				cancel_status: 'wc-cancelled',
+
+				// The advanced pending/OK statuses are opt-in in the UI, but the
+				// capture/cancel paths read them unguarded and only skip on the
+				// literal string 'none'. Absent, the reads are null, the 'none'
+				// guard passes, and update_status( null ) falls back to the
+				// default status — sending a just-captured order to "Pending
+				// payment". 'no' + 'none' is the plugin's own default: advanced
+				// configuration off, statuses left untouched.
+				om_advanced_settings: 'no',
+				capture_pending_status: 'none',
+				capture_ok_status: 'none',
+				cancel_pending_status: 'none',
+				cancel_ok_status: 'none',
+
+				// The remaining keys are all at their plugin defaults and only
+				// listed because they too are read without a guard, on paths hot
+				// enough that the warnings drown out real output: this one is
+				// read in wp_localize_script() on every checkout page load, so
+				// the warning HTML is emitted into the page ahead of the inline
+				// script (classes/class-qliro-one-assets.php).
+				shipping_in_iframe: 'no',
+				// Read on every checkout update-order request; the empty() guard
+				// there sits one line after the array access, so absence warns
+				// on each API round-trip
+				// (classes/requests/put/class-qliro-one-request-update-order.php).
+				shipping_additional_header: '',
+				// Read unguarded while building the create/update-order body
+				// (classes/requests/helpers/class-qliro-one-helper-order-limitations.php).
+				require_id_verification: 'no',
 			},
 		},
 	},


### PR DESCRIPTION
## Why

`options.all.woocommerce_qliro_one_settings` only seeded `enabled`, `testmode`, `logging` and the two test credentials. Because `setSiteOptions` **replaces** the option wholesale — and WooCommerce only writes the `form_fields` defaults when someone saves the settings screen — every other key was simply absent from the database on a fresh playground site.

That is not harmless, because the plugin reads several of those keys straight off `get_option( 'woocommerce_qliro_one_settings' )` with no `isset()` and no default, so the documented defaults in `classes/class-qliro-one-fields.php` were unreachable. Two failures hit while testing refunds with return fees:

1. **Captures never fired.** `Qliro_One_Order_Management::order_status_changed()` does `str_replace( 'wc-', '', $this->settings['capture_status'] )`. With the key missing that is `''`, which never equals the new status, so completing an order never sent `MarkItemsAsShipped`. The admin return-fee row only renders on fully captured orders, so return-fee testing looked broken with no error anywhere.
2. **Captured orders went to "Pending payment".** The capture path is guarded only by `'none' !== $this->settings['capture_pending_status']`. Missing, that reads `null`, the guard passes, and `update_status( null )` falls back to the default status.

## What changed

Only `playground.config.mjs`. The order-management defaults, matching `class-qliro-one-fields.php` exactly:

`capture_status: 'wc-completed'`, `cancel_status: 'wc-cancelled'`, `om_advanced_settings: 'no'`, and `capture_pending_status` / `capture_ok_status` / `cancel_pending_status` / `cancel_ok_status` all `'none'`.

Plus three more keys found by auditing every runtime settings read. These are at their plugin defaults and are here only because they are read without a guard on hot paths, where the warnings drown out real output:

| Key | Read at |
|---|---|
| `shipping_in_iframe` | `wp_localize_script()` on every checkout page load, so the warning HTML lands in the page ahead of the inline script |
| `shipping_additional_header` | every checkout update-order request — the `empty()` guard sits one line *after* the array access |
| `require_id_verification` | while building the create/update-order body |

Keys read via `$this->get_option()` on the gateway were deliberately left out: those do fall back to `form_fields` defaults, so seeding them would be noise.

The comment also documents when edits here actually reach the site, since that determines whether option changes stick: the persistent `start` site applies the blueprint on **fresh provision only** (warm boots skip it, which is what lets wp-admin edits survive a restart), so changes need `start --fresh`. The ephemeral `server development|demo` modes re-apply on every boot.

## Verification

Reprovisioned with `node tools/playground.mjs start --fresh` and queried the site's SQLite directly. All 15 keys land:

```
capture_status -> 'completed'  matches wc status "completed": YES
cancel_status  -> 'cancelled'  matches wc status "cancelled": YES
capture_pending_status   = 'none' -> update_status() skipped: YES
capture_ok_status        = 'none' -> update_status() skipped: YES
cancel_pending_status    = 'none' -> update_status() skipped: YES
cancel_ok_status         = 'none' -> update_status() skipped: YES
```

A real checkout page load (product in cart) now emits `qliroOneParams.shipping_in_iframe: "no"` instead of `null`, and `debug.log` has zero `Undefined array key` / `array offset on value of type bool` entries — only pre-existing WordPress core deprecations.

No changelog entry: `playground.config.mjs` is in `.distignore` and never ships.

## Not done here — for discussion

- **Gateway ordering.** Confirmed on the reprovisioned site that `bacs` renders first and `checked` at checkout, so the Qliro iframe does not load until the customer picks the Qliro radio. Seeding `woocommerce_gateway_order: { qliro_one: 0, bacs: 1 }` would put Qliro first while keeping `bacs` enabled for multi-gateway testing. Left out as an opinionated call — `bacs` is seeded by the shared tooling, not this config, so overriding its position from a single plugin's config is worth agreeing on first.
- **`calculate_return_fee: 'yes'`.** Would make return-fee testing work without a manual settings save, but it changes behavior rather than fixing breakage (the read is correctly guarded with `?? 'no'`), so it stays off.
- **The real fix belongs in the plugin.** These keys should not need seeding at all. Eleven bare `get_option( 'woocommerce_qliro_one_settings' )` calls pass no `array()` default, so on a genuinely fresh install `$this->settings` is `false` and the reads warn about accessing an array offset on a bool. A `qliro_get_setting()` helper merging the `Qliro_One_Fields` defaults over the stored option once would remove the whole class of bug. Worth its own issue; deliberately out of scope for a dev-environment change.

Audit note: the same sweep turned up two unrelated plugin bugs — the widget enable flags are written to separate top-level options but read out of the gateway settings array (so the automatic product/cart-page hooks never register, only the shortcodes work), and `form_fields` defines `payment_widget_data_condensed` while the widget reads `payment_widget_condensed`. Not touched here.