### PR TITLE
Tighten the permission and request validation checks on the admin order actions

### DIFF
--- a/.changelogs/2026-08-24-admin-order-action-checks
+++ b/.changelogs/2026-08-24-admin-order-action-checks
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+Strengthened the permission and request validation checks on the Qliro order actions in the WooCommerce admin.

--- a/classes/class-qliro-one-ajax.php
+++ b/classes/class-qliro-one-ajax.php
@@ -210,7 +210,6 @@ class Qliro_One_Ajax extends WC_AJAX {
 
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			wp_send_json_error( __( 'You do not have permission to change the order management setting.', 'qliro-for-woocommerce' ) );
-			exit;
 		}
 
 		if ( ! $order_id ) {

--- a/classes/class-qliro-one-ajax.php
+++ b/classes/class-qliro-one-ajax.php
@@ -208,6 +208,11 @@ class Qliro_One_Ajax extends WC_AJAX {
 			exit;
 		}
 
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			wp_send_json_error( __( 'You do not have permission to change the order management setting.', 'qliro-for-woocommerce' ) );
+			exit;
+		}
+
 		if ( ! $order_id ) {
 			wp_send_json_error( __( 'No order ID provided.', 'qliro-for-woocommerce' ) );
 			exit;

--- a/classes/class-qliro-order-discount.php
+++ b/classes/class-qliro-order-discount.php
@@ -119,7 +119,6 @@ class Qliro_Order_Discount {
 			$this->handle_error_redirect( 'not_qliro_order', 'metabox_discount' );
 		}
 
-		$order_key = $order->get_order_key();
 		if ( ! hash_equals( $order->get_order_key(), $order_key ) ) {
 			$this->handle_error_redirect( 'invalid_hash', 'metabox_discount' );
 		}


### PR DESCRIPTION
Adds a capability requirement to the order management AJAX handler alongside the existing nonce check, and corrects the order key comparison in the add-discount handler so the value supplied in the request is the one being validated.

https://app.clickup.com/t/2423261/869ejxtrm