### PR TITLE
Verify Qliro callback authenticity before acting on checkout and notification events

### DIFF
--- a/.changelogs/2026-08-24-callback-authenticity
+++ b/.changelogs/2026-08-24-callback-authenticity
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+The refused and on-hold checkout callbacks are now confirmed against the Qliro API before the order status is changed, and the third-party notifications endpoint now verifies that its callback token was issued for the order the notification refers to.

--- a/classes/api/class-qliro-one-callback-auth.php
+++ b/classes/api/class-qliro-one-callback-auth.php
@@ -99,6 +99,32 @@ class Qliro_One_Callback_Auth {
 	}
 
 	/**
+	 * Check whether a callback reference is one the given order was registered with.
+	 *
+	 * A valid token proves only that this site issued it, not which order it was issued for.
+	 *
+	 * @param string   $reference The reference the token was signed for.
+	 * @param WC_Order $order     The order the callback claims to be about.
+	 *
+	 * @return bool True when the reference belongs to the order.
+	 */
+	public static function reference_belongs_to_order( $reference, $order ) {
+		if ( empty( $reference ) || ! $order instanceof WC_Order ) {
+			return false;
+		}
+
+		// The merchant reference covers legacy orders, whose URL was signed with it instead.
+		$known_references = array_filter(
+			array(
+				$order->get_meta( '_qliro_one_order_confirmation_id' ),
+				$order->get_meta( '_qliro_one_merchant_reference' ),
+			)
+		);
+
+		return in_array( (string) $reference, $known_references, true );
+	}
+
+	/**
 	 * Verify the authentication token on an incoming callback request.
 	 *
 	 * Intended for use as a REST permission_callback. Returns true when the request

--- a/classes/api/controllers/class-qliro-one-api-controller-notifications.php
+++ b/classes/api/controllers/class-qliro-one-api-controller-notifications.php
@@ -66,6 +66,33 @@ class Qliro_One_API_Controller_Notifications extends Qliro_One_API_Controller_Ba
 	}
 
 	/**
+	 * Verify that the authenticated token was issued for the order the request body names.
+	 *
+	 * @param WP_REST_Request $request        The request object.
+	 * @param WC_Order|null   $order          The order resolved from the request body.
+	 * @param string          $qliro_order_id The Qliro order id from the request body, used for logging.
+	 *
+	 * @return bool True when the notification may be dispatched.
+	 */
+	protected function token_issued_for_order( $request, $order, $qliro_order_id ) {
+		// Nothing to target, and the order may legitimately not exist yet during checkout.
+		if ( null === $order ) {
+			return true;
+		}
+
+		$reference = $request->get_param( Qliro_One_Callback_Auth::REF_PARAM );
+
+		if ( Qliro_One_Callback_Auth::reference_belongs_to_order( $reference, $order ) ) {
+			return true;
+		}
+
+		Qliro_One_Logger::log( "[CALLBACK AUTH]: Rejected a notification for Qliro order {$qliro_order_id} because its token was not issued for that order. It can be allowed via the 'qliro_one_allow_unauthenticated_callbacks' filter." );
+
+		/** This filter is documented in classes/api/class-qliro-one-callback-auth.php */
+		return (bool) apply_filters( 'qliro_one_allow_unauthenticated_callbacks', false, $request );
+	}
+
+	/**
 	 * Handle the save card callback.
 	 *
 	 * @param WP_REST_Request $request The request object.
@@ -90,6 +117,11 @@ class Qliro_One_API_Controller_Notifications extends Qliro_One_API_Controller_Ba
 			// If the order is returned as 0, set it to null.
 			if ( 0 === $order ) {
 				$order = null;
+			}
+
+			// The order comes from the request body, so confirm the token was issued for it before dispatching anything.
+			if ( ! $this->token_issued_for_order( $request, $order, $qliro_order_id ) ) {
+				return new WP_REST_Response( array( 'error' => 'Callback token was not issued for this order.' ), 401 );
 			}
 
 			// Get the handler for the event type and provider.

--- a/classes/class-qliro-one-callbacks.php
+++ b/classes/class-qliro-one-callbacks.php
@@ -466,6 +466,34 @@ class Qliro_One_Callbacks {
 	}
 
 	/**
+	 * Ask Qliro whether the order really is unpaid, before acting on a status that says so.
+	 *
+	 * The checkout push URL carries no per-order token, so the reported status cannot be
+	 * trusted. Returns false when Qliro cannot be reached, so the order is left alone.
+	 *
+	 * @param WC_Order $order           The order the callback refers to.
+	 * @param string   $reported_status The status claimed by the callback, used for logging.
+	 *
+	 * @return bool True only when Qliro confirms the order has no successful payment.
+	 */
+	private function qliro_confirms_unpaid( $order, $reported_status ) {
+		$qliro_order_id = $order->get_meta( '_qliro_one_order_id' );
+		$qliro_order    = QLIRO_WC()->api->get_qliro_one_admin_order( $qliro_order_id, $order );
+
+		if ( is_wp_error( $qliro_order ) ) {
+			Qliro_One_Logger::log( "Could not retrieve Qliro order {$qliro_order_id} to verify the reported '{$reported_status}' status for WooCommerce order {$order->get_id()}. Leaving the order unchanged. Error: " . $qliro_order->get_error_message() );
+			return false;
+		}
+
+		if ( Qliro_Order_Utility::has_successful_payment( $qliro_order ) ) {
+			Qliro_One_Logger::log( "Ignoring the reported '{$reported_status}' status for WooCommerce order {$order->get_id()}: Qliro order {$qliro_order_id} has a successful payment transaction." );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Process the failed callback from the checkout push.
 	 *
 	 * @param string $confirmation_id The confirmation ID generated in the create call.
@@ -479,6 +507,10 @@ class Qliro_One_Callbacks {
 
 		if ( empty( $order ) ) {
 			Qliro_One_Logger::log( "Could not find an order with the confirmation id $confirmation_id when failing the checkout" );
+			return;
+		}
+
+		if ( ! $this->qliro_confirms_unpaid( $order, 'Refused' ) ) {
 			return;
 		}
 
@@ -507,6 +539,10 @@ class Qliro_One_Callbacks {
 		if ( ! empty( $order->get_date_paid() ) ) {
 			// translators: %s - WooCommerce order number, %s - Qliro Confirmation ID.
 			Qliro_One_Logger::log( sprintf( __( 'Aborting onhold_checkout function. WooCommerce order %1$s with confirmation_id %2$s already confirmed.', 'qliro-for-woocommerce' ), $order->get_order_number(), $confirmation_id ) );
+			return;
+		}
+
+		if ( ! $this->qliro_confirms_unpaid( $order, 'OnHold' ) ) {
 			return;
 		}
 

--- a/classes/class-qliro-order-utility.php
+++ b/classes/class-qliro-order-utility.php
@@ -60,6 +60,29 @@ class Qliro_Order_Utility {
 	}
 
 	/**
+	 * Check whether the Qliro order has any successful payment transaction.
+	 *
+	 * @param array $qliro_order The Qliro order.
+	 *
+	 * @return bool True if at least one processing or capture transaction succeeded.
+	 */
+	public static function has_successful_payment( $qliro_order ) {
+		$transactions = $qliro_order['PaymentTransactions'] ?? array();
+		$paid_types   = array_merge( self::PROCESSING_TRANSACTION_TYPES, array( self::TRANSACTION_TYPE_CAPTURE ) );
+
+		foreach ( $transactions as $transaction ) {
+			$type   = $transaction['Type'] ?? '';
+			$status = $transaction['Status'] ?? '';
+
+			if ( in_array( $type, $paid_types, true ) && self::TRANSACTION_STATUS_SUCCESS === $status ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the last transaction from the Qliro order.
 	 *
 	 * @param array $qliro_order The Qliro order.

--- a/classes/requests/helpers/class-qliro-one-merchant-urls.php
+++ b/classes/requests/helpers/class-qliro-one-merchant-urls.php
@@ -52,10 +52,11 @@ class Qliro_One_Merchant_URLS {
 		}
 
 		$merchant_urls = array(
-			'terms'        => $this->get_terms_url(),
-			'confirmation' => $this->get_confirmation_url( $rand_string, $order ),
-			'push'         => $this->get_push_url( $rand_string ),
-			'om_push'      => $this->get_om_push_url( $rand_string ),
+			'terms'         => $this->get_terms_url(),
+			'confirmation'  => $this->get_confirmation_url( $rand_string, $order ),
+			'push'          => $this->get_push_url( $rand_string ),
+			'om_push'       => $this->get_om_push_url( $rand_string ),
+			'notifications' => $this->get_notifications_url( $rand_string ),
 		);
 
 		// If the cart contains a subscription, add the save card callback url, authenticated with a token.
@@ -118,6 +119,22 @@ class Qliro_One_Merchant_URLS {
 			home_url( '/wc-api/QOC_Checkout_Status/' )
 		);
 		return apply_filters( 'qliro_one_wc_push_url', $checkout_push_url );
+	}
+
+	/**
+	 * Notifications URL.
+	 *
+	 * URL of the third-party notifications callback endpoint, authenticated with a token.
+	 *
+	 * Signed with the confirmation id, since the endpoint has to match the reference back to the order.
+	 *
+	 * @param string $rand_string A random string generated on creation that will follow the entire order process.
+	 * @return string
+	 */
+	private function get_notifications_url( $rand_string ) {
+		$notifications_url = QLIRO_WC()->api_registry()->get_request_path( Qliro_One_API_Controller_Notifications::class, 'notifications' );
+
+		return Qliro_One_Callback_Auth::add_token( $notifications_url, $rand_string );
 	}
 
 	/**

--- a/classes/requests/post/class-qliro-one-request-create-order.php
+++ b/classes/requests/post/class-qliro-one-request-create-order.php
@@ -82,10 +82,7 @@ class Qliro_One_Request_Create_Order extends Qliro_One_Request_Post {
 			'MerchantConfirmationUrl'              => $merchant_urls['confirmation'],
 			'MerchantCheckoutStatusPushUrl'        => $merchant_urls['push'],
 			'MerchantOrderManagementStatusPushUrl' => $merchant_urls['om_push'],
-			'MerchantNotificationUrl'              => Qliro_One_Callback_Auth::add_token(
-				QLIRO_WC()->api_registry()->get_request_path( Qliro_One_API_Controller_Notifications::class, 'notifications' ),
-				$mer_ref
-			),
+			'MerchantNotificationUrl'              => $merchant_urls['notifications'],
 			'MerchantTermsUrl'                     => get_permalink( wc_get_page_id( 'terms' ) ),
 			'MerchantIntegrityPolicyUrl'           => $this->get_integrity_url(),
 			'AskForNewsletterSignup'               => $this->get_ask_for_newsletter(),


### PR DESCRIPTION
https://app.clickup.com/t/2423261/869ejxv8f

### 2.2.3 — Refused / OnHold are confirmed against the Qliro API

The checkout push URL carries no per-order token, so `Refused` and `OnHold` were acted on from the request body alone — a leaked callback URL could mark a paid order as failed. Both branches now re-fetch the order and act only when Qliro reports no successful payment, matching what the `Completed` branch already did. If Qliro cannot be reached, the order is left untouched.

### 2.2.4 — The notifications endpoint binds the token to the order

The endpoint verified that its token was one this site issued, but took the order from the request body, so a notification URL leaked from one order could dispatch internal events against any other order. It now confirms the signed reference belongs to the order the body names.

The notification URL is also built alongside the other callback URLs now, and signed with the confirmation id, so every callback URL for an order carries the same per-order reference.

### Verification

Tested on the sandbox with real purchases through the invoice flow, with Qliro transmitting the callbacks itself.

| Attack | `develop` | This branch |
| --- | --- | --- |
| Forged `Refused` on a genuinely paid order | order → `failed` | unchanged |
| Forged `OnHold`, pre-confirmation race | — | unchanged |
| Token for order A, notification naming order B | `200`, cross-order write lands | `401`, no write |
| Token used for its own order | `200` | `200` |

Regression: the real `QOC_Checkout_Status` and `QOC_OM_Status` pushes Qliro sends both return `200`, the tokenised OM push verifies, and the order completes to `processing` / paid.

### Notes for review

- Orders created before this change were signed with the merchant reference, which stays on the order, so they still bind — the reference check accepts either value. They do **not** need the grace filter.
- Confirmation ids are shared within a subscription family (parent order, subscription, renewals), which also share one Qliro order id. The binding accepts a token across those by design.