### PR TITLE
Illegal SKU chars handling

### DIFF
--- a/.changelogs/2026-08-24-invalid-sku-characters
+++ b/.changelogs/2026-08-24-invalid-sku-characters
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: yes
+
+Products whose SKU contains characters that Qliro does not accept are now flagged when the product is saved, and customers get a clear message in the checkout.

--- a/classes/class-qliro-one-product-tab.php
+++ b/classes/class-qliro-one-product-tab.php
@@ -28,7 +28,7 @@ class Qliro_One_Product_Tab {
 	 * @return void
 	 */
 	public function validate_sku( $product ) {
-		$notice = qliro_one_get_invalid_sku_notice( $product->get_sku() );
+		$notice = qliro_one_get_invalid_sku_notice( $product->get_sku( 'edit' ) );
 		if ( ! empty( $notice ) ) {
 			WC_Admin_Meta_Boxes::add_error( $notice );
 		}

--- a/classes/class-qliro-one-product-tab.php
+++ b/classes/class-qliro-one-product-tab.php
@@ -112,4 +112,5 @@ class Qliro_One_Product_Tab {
 		$product->update_meta_data( 'qoc_has_risk', $has_risk ?? 'no' );
 		$product->save();
 	}
-} new Qliro_One_Product_Tab();
+}
+new Qliro_One_Product_Tab();

--- a/classes/class-qliro-one-product-tab.php
+++ b/classes/class-qliro-one-product-tab.php
@@ -17,6 +17,21 @@ class Qliro_One_Product_Tab {
 		add_action( 'woocommerce_product_data_panels', array( $this, 'product_options' ) );
 		add_action( 'woocommerce_process_product_meta_simple', array( $this, 'save_product_options' ) );
 		add_action( 'woocommerce_process_product_meta_variable', array( $this, 'save_product_options' ) );
+		add_action( 'woocommerce_admin_process_product_object', array( $this, 'validate_sku' ) );
+		add_action( 'woocommerce_admin_process_variation_object', array( $this, 'validate_sku' ) );
+	}
+
+	/**
+	 * Warns the merchant when a saved SKU contains characters that Qliro does not accept.
+	 *
+	 * @param WC_Product $product The product or product variation being saved.
+	 * @return void
+	 */
+	public function validate_sku( $product ) {
+		$notice = qliro_one_get_invalid_sku_notice( $product->get_sku() );
+		if ( ! empty( $notice ) ) {
+			WC_Admin_Meta_Boxes::add_error( $notice );
+		}
 	}
 
 	/**

--- a/classes/requests/class-qliro-one-request.php
+++ b/classes/requests/class-qliro-one-request.php
@@ -204,7 +204,11 @@ abstract class Qliro_One_Request {
 				}
 				break;
 			case 'INVALID_INPUT':
-				$message = __( 'Qliro is unfortunately not available for this order. Please choose another payment method, or contact us if the problem continues. Error code INVALID_INPUT', 'qliro-for-woocommerce' );
+				$message = sprintf(
+					/* translators: %s: Qliro API error code. */
+					__( 'Qliro is unfortunately not available for this order. Please choose another payment method, or contact us if the problem continues. Error code %s', 'qliro-for-woocommerce' ),
+					$error_code
+				);
 				break;
 			case 'NO_ITEMS_LEFT_IN_RESERVATION':
 				$message = __( 'The order has already been captured.', 'qliro-for-woocommerce' );

--- a/classes/requests/class-qliro-one-request.php
+++ b/classes/requests/class-qliro-one-request.php
@@ -203,6 +203,9 @@ abstract class Qliro_One_Request {
 					$message = __( 'Qliro is not configured for the selected country and currency. Please select a different payment method or country.', 'qliro-for-woocommerce' );
 				}
 				break;
+			case 'INVALID_INPUT':
+				$message = __( 'Qliro is unfortunately not available for this order. Please choose another payment method, or contact us if the problem continues. Error code INVALID_INPUT', 'qliro-for-woocommerce' );
+				break;
 			case 'NO_ITEMS_LEFT_IN_RESERVATION':
 				$message = __( 'The order has already been captured.', 'qliro-for-woocommerce' );
 				break;

--- a/includes/qliro-one-functions.php
+++ b/includes/qliro-one-functions.php
@@ -669,6 +669,40 @@ function qliro_one_format_fee_reference( $fee_name ) {
 }
 
 /**
+ * Get the characters in a merchant reference that Qliro does not accept.
+ *
+ * @param string $reference The reference (product SKU) to check.
+ *
+ * @return array Unique disallowed characters, empty if the reference is valid.
+ */
+function qliro_one_get_invalid_reference_characters( $reference ) {
+	preg_match_all( "/[^\p{L}\s(.)'\-_&,\/–+0-9:|]/u", (string) $reference, $matches );
+
+	return array_values( array_unique( $matches[0] ) );
+}
+
+/**
+ * Get the merchant facing warning for a SKU that Qliro will reject, or an empty string if the SKU is valid.
+ *
+ * @param string $sku The product SKU.
+ *
+ * @return string
+ */
+function qliro_one_get_invalid_sku_notice( $sku ) {
+	$invalid_characters = qliro_one_get_invalid_reference_characters( $sku );
+	if ( empty( $invalid_characters ) ) {
+		return '';
+	}
+
+	return sprintf(
+		/* translators: 1: the product SKU, 2: comma separated list of the characters Qliro does not accept. */
+		__( 'The SKU %1$s contains characters that Qliro doesn\'t accept (%2$s). Customers will not be able to complete Qliro checkout with this product in their cart. Remove the highlighted characters — Qliro allows letters, numbers, spaces and ( . ) \' - _ &amp; , / – + : |.', 'qliro-for-woocommerce' ),
+		'<strong>' . esc_html( $sku ) . '</strong>',
+		esc_html( implode( ', ', $invalid_characters ) )
+	);
+}
+
+/**
  * Get the billing country from the checkout, or the store base location if not set.
  *
  * @return string


### PR DESCRIPTION
- Improves the customer-facing error message in checkout when non-allowed characters are included in the merchant reference (SKU).
- Adds error messaging regarding the non-allowed SKU value when products are saved in WooCommerce